### PR TITLE
feat(deploy): Zero-install deployment using pnpm deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,16 +41,18 @@ jobs:
       - name: Build backend
         run: pnpm server:build
 
+      - name: Deploy server package with dependencies
+        run: pnpm --filter=@nsx/server --prod deploy --legacy .deploy-server
+
       - name: Create artifact
         run: |
           mkdir -p deploy
           cp -r build/ deploy/
           cp -r server_build/ deploy/
-          cp -r prisma/ deploy/          
+          cp -r .deploy-server/node_modules/ deploy/
+          cp -r prisma/ deploy/
           cp ecosystem.config.js deploy/
           cp compose.yml deploy/
-          cp package.json deploy/
-          cp pnpm-lock.yaml deploy/
 
       - name: Upload build artifact
         uses: actions/upload-artifact@v4
@@ -80,7 +82,7 @@ jobs:
           strip_components: 1
           debug: true
 
-      - name: Setup .env and install dependencies
+      - name: Setup .env and restart server
         uses: appleboy/ssh-action@v1
         with:
           host: ${{ secrets.SSH_HOST }}
@@ -95,8 +97,6 @@ jobs:
             BLUESKY_USERNAME=${{ secrets.BLUESKY_USERNAME }}
             BLUESKY_PASSWORD=${{ secrets.BLUESKY_PASSWORD }}
             EOL
-            pnpm install --prod
-            pnpm prisma migrate deploy
-            sudo pm2 status
-            sudo pm2 delete ecosystem.config.js
+            ./node_modules/.bin/prisma migrate deploy
+            sudo pm2 delete ecosystem.config.js || true
             sudo pm2 start ecosystem.config.js

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -489,6 +489,63 @@ importers:
         specifier: ^0.20.11
         version: 0.20.11(@types/node@24.10.1)(jiti@2.6.1)(lightningcss@1.30.2)(rollup@4.53.3)(terser@5.44.1)(tsx@4.20.6)(yaml@2.8.1)
 
+  server:
+    dependencies:
+      '@atproto/api':
+        specifier: ^0.18.3
+        version: 0.18.3
+      '@prisma/adapter-mariadb':
+        specifier: 7.0.1
+        version: 7.0.1
+      '@prisma/client':
+        specifier: 7.0.1
+        version: 7.0.1(prisma@7.0.1(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3))(typescript@5.9.3)
+      bcrypt:
+        specifier: ^6.0.0
+        version: 6.0.0
+      body-parser:
+        specifier: ^2.2.1
+        version: 2.2.1
+      chalk:
+        specifier: ^4.1.2
+        version: 4.1.2
+      compression:
+        specifier: ^1.8.1
+        version: 1.8.1
+      cookie-parser:
+        specifier: ^1.4.7
+        version: 1.4.7
+      cors:
+        specifier: ^2.8.5
+        version: 2.8.5
+      cron:
+        specifier: ^4.3.4
+        version: 4.3.4
+      dotenv:
+        specifier: ^17.2.3
+        version: 17.2.3
+      express:
+        specifier: ^5.1.0
+        version: 5.1.0
+      http-errors:
+        specifier: ^2.0.1
+        version: 2.0.1
+      jsonwebtoken:
+        specifier: ^9.0.2
+        version: 9.0.2
+      morgan:
+        specifier: ^1.10.1
+        version: 1.10.1
+      mysql2:
+        specifier: ^3.15.3
+        version: 3.15.3
+      openai:
+        specifier: ^6.9.1
+        version: 6.9.1(ws@8.18.3)(zod@4.1.13)
+      prisma:
+        specifier: ^7.0.1
+        version: 7.0.1(@types/react@19.2.7)(magicast@0.3.5)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.9.3)
+
 packages:
 
   '@1natsu/wait-element@4.1.2':

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - browser-extension
+  - server

--- a/server/package.json
+++ b/server/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@nsx/server",
+  "private": true,
+  "version": "0.0.1",
+  "description": "NSX Backend Server - Express API with Prisma ORM",
+  "dependencies": {
+    "@atproto/api": "^0.18.3",
+    "@prisma/adapter-mariadb": "7.0.1",
+    "@prisma/client": "7.0.1",
+    "bcrypt": "^6.0.0",
+    "body-parser": "^2.2.1",
+    "chalk": "^4.1.2",
+    "compression": "^1.8.1",
+    "cookie-parser": "^1.4.7",
+    "cors": "^2.8.5",
+    "cron": "^4.3.4",
+    "dotenv": "^17.2.3",
+    "express": "^5.1.0",
+    "http-errors": "^2.0.1",
+    "jsonwebtoken": "^9.0.2",
+    "morgan": "^1.10.1",
+    "mysql2": "^3.15.3",
+    "openai": "^6.9.1",
+    "prisma": "^7.0.1"
+  }
+}


### PR DESCRIPTION
## Summary

Implements zero-install deployment by pre-packaging backend dependencies in CI using pnpm's `deploy` command, eliminating the need for `pnpm install` on the production server.

## Problem

- Production server experiences **high load (70+)** during `pnpm install` due to limited resources
- Limited storage on production server
- `pnpm install --prod` still installs unnecessary frontend deps (React, UI libraries, etc.)

## Solution

Use pnpm's built-in [`deploy` command](https://pnpm.io/cli/deploy) to create an isolated deployment package with only backend dependencies.

### Changes

| File | Change |
|------|--------|
| `server/package.json` | **New** - Backend-only dependencies (~17 packages) |
| `pnpm-workspace.yaml` | Add `server` as workspace package |
| `deploy.yml` | Add `pnpm deploy` step, remove `pnpm install` from production |
| `pnpm-lock.yaml` | Updated for new workspace package |

### New Deployment Flow

```
CI → Build → pnpm deploy → rsync (with node_modules) → Production: PM2 restart
                                                       ↑ NO INSTALL!
```

### Backend Dependencies (server/package.json)

```json
{
  "@atproto/api",      // Bluesky integration
  "@prisma/client",    // Database ORM
  "@prisma/adapter-mariadb",
  "bcrypt",            // Password hashing
  "body-parser",       // Request parsing
  "chalk",             // Logging colors
  "compression",       // Response compression
  "cookie-parser",     // Cookie handling
  "cors",              // CORS support
  "cron",              // Scheduled tasks
  "dotenv",            // Environment variables
  "express",           // Web framework
  "http-errors",       // HTTP errors
  "jsonwebtoken",      // JWT auth
  "morgan",            // HTTP logger
  "mysql2",            // MySQL driver
  "openai",            // Translation
  "prisma"             // Prisma CLI (migrations)
}
```

## Benefits

| Metric | Before | After |
|--------|--------|-------|
| `pnpm install` on prod | Yes (high load) | **No** |
| Packages in prod | ~35 | ~17 |
| Server load during deploy | 70+ | **Minimal** |

## Testing

- [x] `pnpm install` - Workspace links correctly
- [x] `pnpm typecheck` - No TypeScript errors
- [x] `pnpm lint` - No linting errors
- [x] `pnpm server:build` - Server compiles successfully
- [x] `pnpm --filter=@nsx/server --prod deploy --legacy .deploy-server-test` - Deploy command works

## Closes

Closes #3635