### PR TITLE
fix: remove Headless UI dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@atproto/api": "^0.19.19",
-    "@headlessui/react": "^1.7.19",
     "@heroicons/react": "^2.2.0",
     "@hookform/resolvers": "^5.4.0",
     "@prisma/adapter-mariadb": "7.8.0",
@@ -67,7 +66,6 @@
     "@faker-js/faker": "^10.4.0",
     "@laststance/react-next-eslint-plugin": "^2.2.0",
     "@playwright/test": "^1.60.0",
-    "code-inspector-plugin": "^1.5.1",
     "@redocly/cli": "^2.31.4",
     "@storybook/addon-a11y": "^10.3.5",
     "@storybook/addon-docs": "^10.3.5",
@@ -100,6 +98,7 @@
     "@vitest/coverage-v8": "^4.1.7",
     "@vitest/ui": "^4.1.7",
     "all-contributors-cli": "^6.26.1",
+    "code-inspector-plugin": "^1.5.1",
     "concurrently": "^9.2.1",
     "cross-env": "^10.1.0",
     "dotenv-cli": "^11.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
       '@atproto/api':
         specifier: ^0.19.19
         version: 0.19.19
-      '@headlessui/react':
-        specifier: ^1.7.19
-        version: 1.7.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@heroicons/react':
         specifier: ^2.2.0
         version: 2.2.0(react@19.2.6)
@@ -1214,13 +1211,6 @@ packages:
   '@fregante/relaxed-json@2.0.0':
     resolution: {integrity: sha512-PyUXQWB42s4jBli435TDiYuVsadwRHnMc27YaLouINktvTWsL3FcKrRMGawTayFk46X+n5bE23RjUTWQwrukWw==}
     engines: {node: '>= 0.10.0'}
-
-  '@headlessui/react@1.7.19':
-    resolution: {integrity: sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      react: ^19.2.1
-      react-dom: ^19.2.1
 
   '@heroicons/react@2.2.0':
     resolution: {integrity: sha512-LMcepvRaS9LYHJGsF0zzmgKCUim/X3N/DQKc4jepAXJ7l8QxJ1PmxJzqplF2Z3FE4PqBAIGyJAQ/w4B5dsqbtQ==}
@@ -2509,15 +2499,6 @@ packages:
     peerDependencies:
       tailwindcss: '>=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1'
 
-  '@tanstack/react-virtual@3.13.23':
-    resolution: {integrity: sha512-XnMRnHQ23piOVj2bzJqHrRrLg4r+F86fuBcwteKfbIjJrtGxb4z7tIvPVAe4B+4UVwo9G4Giuz5fmapcrnZ0OQ==}
-    peerDependencies:
-      react: ^19.2.1
-      react-dom: ^19.2.1
-
-  '@tanstack/virtual-core@3.13.23':
-    resolution: {integrity: sha512-zSz2Z2HNyLjCplANTDyl3BcdQJc2k1+yyFoKhNRmCr7V7dY8o8q5m8uFTI1/Pg1kL+Hgrz6u3Xo6eFUB7l66cg==}
-
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
     engines: {node: '>=18'}
@@ -3706,9 +3687,6 @@ packages:
   cli-width@4.1.0:
     resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
     engines: {node: '>= 12'}
-
-  client-only@0.0.1:
-    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   cliui@6.0.0:
     resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
@@ -9025,13 +9003,6 @@ snapshots:
 
   '@fregante/relaxed-json@2.0.0': {}
 
-  '@headlessui/react@1.7.19(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@tanstack/react-virtual': 3.13.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      client-only: 0.0.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
   '@heroicons/react@2.2.0(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -10139,14 +10110,6 @@ snapshots:
     dependencies:
       postcss-selector-parser: 6.0.10
       tailwindcss: 4.3.0
-
-  '@tanstack/react-virtual@3.13.23(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@tanstack/virtual-core': 3.13.23
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@tanstack/virtual-core@3.13.23': {}
 
   '@testing-library/dom@10.4.1':
     dependencies:
@@ -11586,8 +11549,6 @@ snapshots:
 
   cli-width@4.1.0: {}
 
-  client-only@0.0.1: {}
-
   cliui@6.0.0:
     dependencies:
       string-width: 4.2.3
@@ -12386,7 +12347,7 @@ snapshots:
       eslint: 10.4.0(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@10.4.0(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.10)(eslint@10.4.0(jiti@2.7.0))
-      hasown: 2.0.2
+      hasown: 2.0.3
       is-core-module: 2.16.1
       is-glob: 4.0.3
       minimatch: 3.1.5
@@ -13033,7 +12994,7 @@ snapshots:
       '@types/ws': 8.18.1
       entities: 7.0.1
       whatwg-mimetype: 3.0.0
-      ws: 8.20.0
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,12 +1,16 @@
 import { XMarkIcon } from '@heroicons/react/24/outline'
-import React, { memo } from 'react'
+import React, { memo, useRef } from 'react'
 
 import TweetLink from '@/src/components/Sidebar/TweetLink'
 
 import { useIsomorphicEffect } from '../../hooks/useIsomorphicEffect'
 import { selectLogin } from '../../redux/adminSlice'
 import { useAppSelector } from '../../redux/hooks'
-import { selectSidebarOpen, toggleSidebar } from '../../redux/sidebarSlice'
+import {
+  closeSidebar,
+  selectSidebarOpen,
+  toggleSidebar,
+} from '../../redux/sidebarSlice'
 import { dispatch } from '../../redux/store'
 
 import CreateLink from './CreateLink'
@@ -15,6 +19,43 @@ import LoginLink from './LoginLink'
 import LogoutLink from './LogoutLink'
 import { onCloseHander } from './onCloseHander'
 import SettingLink from './SettingLink'
+
+const FOCUSABLE_SIDEBAR_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',')
+
+/**
+ * Returns keyboard-focusable elements inside the open sidebar.
+ * @param container - The sidebar root element that owns focus while open.
+ * @returns
+ * - When mounted: focusable descendants in DOM order
+ * - When unmounted: an empty array
+ * @example
+ * getFocusableElements(document.querySelector('aside')) // => [HTMLAnchorElement, HTMLButtonElement]
+ */
+const getFocusableElements = (container: HTMLElement | null): HTMLElement[] => {
+  if (!container) return []
+
+  return Array.from(
+    container.querySelectorAll<HTMLElement>(FOCUSABLE_SIDEBAR_SELECTOR),
+  ).filter(isVisibleFocusableElement)
+}
+
+/**
+ * Keeps hidden or inert nodes out of manual focus trap cycling.
+ * @param element - A candidate element matched by the focusable selector.
+ * @returns Whether the element can currently receive keyboard focus.
+ * @example
+ * isVisibleFocusableElement(document.createElement('button')) // => true
+ */
+const isVisibleFocusableElement = (element: HTMLElement): boolean => {
+  return Boolean(element.offsetParent || element.getClientRects().length)
+}
 
 /**
  * Toggles the sidebar from the global shortcut used by the admin flows.
@@ -37,6 +78,8 @@ const keypressListener = (event: KeyboardEvent) => {
 const Sidebar: React.FC = memo(() => {
   const open = useAppSelector(selectSidebarOpen)
   const login = useAppSelector(selectLogin)
+  const sidebarRef = useRef<HTMLElement>(null)
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null)
 
   useIsomorphicEffect(() => {
     window.document.addEventListener('keyup', keypressListener)
@@ -45,6 +88,62 @@ const Sidebar: React.FC = memo(() => {
       window.document.removeEventListener('keyup', keypressListener)
     }
   }, [])
+
+  useIsomorphicEffect(() => {
+    // Focus management is only active while the dialog markup exists.
+    if (!open) return undefined
+
+    const activeElement = window.document.activeElement
+    previouslyFocusedElementRef.current =
+      activeElement instanceof HTMLElement ? activeElement : null
+
+    const [firstFocusableElement] = getFocusableElements(sidebarRef.current)
+    firstFocusableElement?.focus()
+
+    return () => {
+      // Restore focus to the opener when the sidebar unmounts after close.
+      if (previouslyFocusedElementRef.current?.isConnected) {
+        previouslyFocusedElementRef.current.focus()
+      }
+    }
+  }, [open])
+
+  const handleSidebarKeyDown = (event: React.KeyboardEvent<HTMLElement>) => {
+    if (event.key === 'Escape') {
+      event.preventDefault()
+      dispatch(closeSidebar())
+      return
+    }
+
+    // Only Tab needs wrapping; all other keys keep their native behavior.
+    if (event.key !== 'Tab') return
+
+    const focusableElements = getFocusableElements(sidebarRef.current)
+    const [firstFocusableElement] = focusableElements
+    const lastFocusableElement = focusableElements.at(-1)
+
+    if (!firstFocusableElement || !lastFocusableElement) {
+      event.preventDefault()
+      return
+    }
+
+    if (
+      event.shiftKey &&
+      window.document.activeElement === firstFocusableElement
+    ) {
+      event.preventDefault()
+      lastFocusableElement.focus()
+      return
+    }
+
+    if (
+      !event.shiftKey &&
+      window.document.activeElement === lastFocusableElement
+    ) {
+      event.preventDefault()
+      firstFocusableElement.focus()
+    }
+  }
 
   // Keep the closed state out of the DOM so keyboard users do not tab into hidden links.
   if (!open) return null
@@ -55,11 +154,13 @@ const Sidebar: React.FC = memo(() => {
       aria-modal="true"
       className="relative z-40"
       role="dialog"
+      onKeyDown={handleSidebarKeyDown}
     >
       <div className="bg-opacity-75 fixed inset-0 bg-gray-600" />
 
       <div className="fixed inset-0 z-40 flex" onClick={onCloseHander}>
         <aside
+          ref={sidebarRef}
           className="relative flex w-full max-w-xs flex-1 flex-col bg-gray-800 pt-5 pb-4"
           onClick={(event) => {
             // Prevent clicks inside the drawer from bubbling to the backdrop close handler.

--- a/src/components/Sidebar/index.tsx
+++ b/src/components/Sidebar/index.tsx
@@ -1,4 +1,3 @@
-import { Dialog, Transition } from '@headlessui/react'
 import { XMarkIcon } from '@heroicons/react/24/outline'
 import React, { memo } from 'react'
 
@@ -17,99 +16,91 @@ import LogoutLink from './LogoutLink'
 import { onCloseHander } from './onCloseHander'
 import SettingLink from './SettingLink'
 
-Dialog.displayName = 'Dialog'
-Dialog.Panel.displayName = 'Dialog.Panel'
-Transition.Root.displayName = 'Transition.Root'
-Transition.Child.displayName = 'Transition.Child'
-
-const keypressListener = (e: KeyboardEvent) => {
+/**
+ * Toggles the sidebar from the global shortcut used by the admin flows.
+ * @param event - The keyup event emitted by the document.
+ * @returns Nothing; dispatches only when the shortcut key is pressed.
+ * @example
+ * keypressListener(new KeyboardEvent('keyup', { key: 'x' }))
+ */
+const keypressListener = (event: KeyboardEvent) => {
   // @TODO add (if not while typing in a text input
-  if (e.key === 'x') dispatch(toggleSidebar())
+  if (event.key === 'x') dispatch(toggleSidebar())
 }
 
+/**
+ * Renders the app navigation drawer without Headless UI so the app has fewer runtime dependencies.
+ * @returns The open sidebar dialog, or null when the sidebar is closed.
+ * @example
+ * <Sidebar />
+ */
 const Sidebar: React.FC = memo(() => {
   const open = useAppSelector(selectSidebarOpen)
   const login = useAppSelector(selectLogin)
 
   useIsomorphicEffect(() => {
     window.document.addEventListener('keyup', keypressListener)
+
+    return () => {
+      window.document.removeEventListener('keyup', keypressListener)
+    }
   }, [])
 
-  return (
-    <>
-      <Transition.Root show={open}>
-        <Dialog as="section" className="relative z-40" onClose={onCloseHander}>
-          <Transition.Child
-            enter="transition-opacity ease-linear duration-300"
-            enterFrom="opacity-0"
-            enterTo="opacity-100"
-            leave="transition-opacity ease-linear duration-300"
-            leaveFrom="opacity-100"
-            leaveTo="opacity-0"
-          >
-            <div className="bg-opacity-75 fixed inset-0 bg-gray-600" />
-          </Transition.Child>
+  // Keep the closed state out of the DOM so keyboard users do not tab into hidden links.
+  if (!open) return null
 
-          <div className="fixed inset-0 z-40 flex">
-            <Transition.Child
-              enter="transition ease-in-out duration-300 transform"
-              enterFrom="-translate-x-full"
-              enterTo="translate-x-0"
-              leave="transition ease-in-out duration-300 transform"
-              leaveFrom="translate-x-0"
-              leaveTo="-translate-x-full"
+  return (
+    <section
+      aria-label="Sidebar navigation"
+      aria-modal="true"
+      className="relative z-40"
+      role="dialog"
+    >
+      <div className="bg-opacity-75 fixed inset-0 bg-gray-600" />
+
+      <div className="fixed inset-0 z-40 flex" onClick={onCloseHander}>
+        <aside
+          className="relative flex w-full max-w-xs flex-1 flex-col bg-gray-800 pt-5 pb-4"
+          onClick={(event) => {
+            // Prevent clicks inside the drawer from bubbling to the backdrop close handler.
+            event.stopPropagation()
+          }}
+        >
+          <div className="absolute top-0 right-0 -mr-12 pt-2">
+            <button
+              type="button"
+              className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:ring-2 focus:ring-white focus:outline-hidden focus:ring-inset"
+              onClick={onCloseHander}
             >
-              <Dialog.Panel className="relative flex w-full max-w-xs flex-1 flex-col bg-gray-800 pt-5 pb-4">
-                <Transition.Child
-                  enter="ease-in-out duration-300"
-                  enterFrom="opacity-0"
-                  enterTo="opacity-100"
-                  leave="ease-in-out duration-300"
-                  leaveFrom="opacity-100"
-                  leaveTo="opacity-0"
-                >
-                  <div className="absolute top-0 right-0 -mr-12 pt-2">
-                    <button
-                      type="button"
-                      className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:ring-2 focus:ring-white focus:outline-hidden focus:ring-inset"
-                      onClick={onCloseHander}
-                    >
-                      <span className="sr-only">Close sidebar</span>
-                      <XMarkIcon
-                        className="h-6 w-6 text-white"
-                        aria-hidden="true"
-                      />
-                    </button>
-                  </div>
-                </Transition.Child>
-                <div className="flex shrink-0 items-center px-4">
-                  <img
-                    className="h-8 w-auto"
-                    src="https://tailwindui.com/img/logos/workflow-logo-indigo-500-mark-white-text.svg"
-                    alt="Workflow"
-                  />
-                </div>
-                <div className="mt-5 h-0 flex-1 overflow-y-auto">
-                  <nav className="space-y-1 px-2">
-                    {login ? <LogoutLink /> : <LoginLink />}
-                    {login && (
-                      <>
-                        <SettingLink />
-                        <DashboardLink />
-                        <CreateLink />
-                        <TweetLink />
-                      </>
-                    )}
-                  </nav>
-                </div>
-              </Dialog.Panel>
-            </Transition.Child>
+              <span className="sr-only">Close sidebar</span>
+              <XMarkIcon className="h-6 w-6 text-white" aria-hidden="true" />
+            </button>
           </div>
-        </Dialog>
-      </Transition.Root>
-    </>
+          <div className="flex shrink-0 items-center px-4">
+            <img
+              className="h-8 w-auto"
+              src="https://tailwindui.com/img/logos/workflow-logo-indigo-500-mark-white-text.svg"
+              alt="Workflow"
+            />
+          </div>
+          <div className="mt-5 h-0 flex-1 overflow-y-auto">
+            <nav className="space-y-1 px-2">
+              {login ? <LogoutLink /> : <LoginLink />}
+              {login && (
+                <>
+                  <SettingLink />
+                  <DashboardLink />
+                  <CreateLink />
+                  <TweetLink />
+                </>
+              )}
+            </nav>
+          </div>
+        </aside>
+      </div>
+    </section>
   )
 })
-Sidebar.displayName = 'HeadlessEffect.Sidebar'
+Sidebar.displayName = 'Sidebar'
 
 export default Sidebar

--- a/src/components/ToggleTheme/index.tsx
+++ b/src/components/ToggleTheme/index.tsx
@@ -1,13 +1,22 @@
-import { Listbox } from '@headlessui/react'
 import clsx from 'clsx'
-import React, { memo } from 'react'
+import React, { memo, useEffect, useRef, useState } from 'react'
+
+import type { Theme } from '../../redux/themeSlice'
 
 import MoonIcon from './MoonIcon'
 import PcIcon from './PCIcon'
 import SunIcon from './SunIcon'
 import { useTheme } from './useTheme'
 
-const options = [
+const THEME_MENU_OPTIONS_ID = 'theme-menu-options'
+
+interface ThemeOption {
+  icon: typeof SunIcon
+  label: string
+  value: Theme
+}
+
+const options: ThemeOption[] = [
   {
     icon: SunIcon,
     label: 'Light',
@@ -25,51 +34,114 @@ const options = [
   },
 ]
 
-// @TODO Extract from leadless UI
-Listbox.displayName = 'Listbox'
-Listbox.Label.displayName = 'Listbox.Label'
-Listbox.Button.displayName = 'Listbox.Button'
-Listbox.Options.displayName = 'Listbox.Options'
-Listbox.Option.displayName = 'Listbox.Option'
-
+/**
+ * Renders the theme picker without Headless UI while keeping the existing E2E selectors stable.
+ * @returns A button-triggered listbox for selecting light, dark, or system theme.
+ * @example
+ * <ThemeToggle />
+ */
 const ThemeToggle = memo(() => {
   const [theme, updateTheme] = useTheme()
+  const [isMenuOpen, setIsMenuOpen] = useState(false)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  useEffect(() => {
+    // Skip the document listener while closed so normal page clicks stay untouched.
+    if (!isMenuOpen) return undefined
+
+    const handleDocumentMouseDown = (event: MouseEvent) => {
+      const targetNode = event.target
+
+      // Clicking inside the menu should not close it before the option handler runs.
+      if (targetNode instanceof Node && rootRef.current?.contains(targetNode)) {
+        return
+      }
+
+      setIsMenuOpen(false)
+    }
+
+    document.addEventListener('mousedown', handleDocumentMouseDown)
+
+    return () => {
+      document.removeEventListener('mousedown', handleDocumentMouseDown)
+    }
+  }, [isMenuOpen])
+
+  const handleThemeSelect = (nextTheme: Theme) => {
+    updateTheme(nextTheme)
+    setIsMenuOpen(false)
+    buttonRef.current?.focus()
+  }
+
+  const handleMenuKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    // Escape mirrors native select dismissal and returns focus to the trigger.
+    if (event.key === 'Escape') {
+      setIsMenuOpen(false)
+      buttonRef.current?.focus()
+    }
+  }
 
   return (
-    <Listbox as="div" value={theme} onChange={updateTheme}>
-      <Listbox.Label className="sr-only">Theme</Listbox.Label>
+    <div ref={rootRef} onKeyDown={handleMenuKeyDown}>
+      <span className="sr-only" id="theme-menu-label">
+        Theme
+      </span>
       <div className="relative">
-        <Listbox.Button type="button" data-testid="theme-menu-button">
+        <button
+          ref={buttonRef}
+          aria-controls={THEME_MENU_OPTIONS_ID}
+          aria-expanded={isMenuOpen}
+          aria-haspopup="listbox"
+          aria-labelledby="theme-menu-label"
+          type="button"
+          data-testid="theme-menu-button"
+          onClick={() => {
+            setIsMenuOpen((currentIsMenuOpen) => !currentIsMenuOpen)
+          }}
+        >
           <span className="dark:hidden">
             <SunIcon className="h-6 w-6" selected={theme !== 'system'} />
           </span>
           <span className="hidden dark:inline">
             <MoonIcon className="h-6 w-6" selected={theme !== 'system'} />
           </span>
-        </Listbox.Button>
-        <Listbox.Options className="dark:highlight-white/5 absolute top-5 -right-16 z-50 mt-4 w-36 overflow-hidden rounded-lg bg-white py-1 text-sm font-semibold text-slate-700 shadow-lg ring-1 ring-slate-900/10 dark:bg-neutral-700 dark:text-slate-300 dark:ring-0">
-          {options.map(({ icon: Icon, label, value }) => (
-            <Listbox.Option
-              key={value}
-              value={value}
-              className={clsx(
-                'flex cursor-pointer items-center px-2 py-1',
-                'data-[headlessui-state~="active"]:bg-slate-50 data-[headlessui-state~="active"]:dark:bg-slate-600/30',
-                'data-[headlessui-state~="selected"]:text-green-400',
-              )}
-              data-testid={`theme-select-option-${value}`}
-            >
-              {({ selected }) => (
-                <>
-                  <Icon selected={selected} className="mr-2 h-6 w-6" />
+        </button>
+        {isMenuOpen && (
+          <div
+            aria-labelledby="theme-menu-label"
+            className="dark:highlight-white/5 absolute top-5 -right-16 z-50 mt-4 w-36 overflow-hidden rounded-lg bg-white py-1 text-sm font-semibold text-slate-700 shadow-lg ring-1 ring-slate-900/10 dark:bg-neutral-700 dark:text-slate-300 dark:ring-0"
+            id={THEME_MENU_OPTIONS_ID}
+            role="listbox"
+          >
+            {options.map(({ icon: Icon, label, value }) => {
+              const isSelected = theme === value
+
+              return (
+                <button
+                  key={value}
+                  aria-selected={isSelected}
+                  className={clsx(
+                    'flex w-full cursor-pointer items-center px-2 py-1 text-left',
+                    'hover:bg-slate-50 focus:bg-slate-50 focus:outline-hidden dark:hover:bg-slate-600/30 dark:focus:bg-slate-600/30',
+                    isSelected && 'text-green-400',
+                  )}
+                  data-testid={`theme-select-option-${value}`}
+                  role="option"
+                  type="button"
+                  onClick={() => {
+                    handleThemeSelect(value)
+                  }}
+                >
+                  <Icon selected={isSelected} className="mr-2 h-6 w-6" />
                   {label}
-                </>
-              )}
-            </Listbox.Option>
-          ))}
-        </Listbox.Options>
+                </button>
+              )
+            })}
+          </div>
+        )}
       </div>
-    </Listbox>
+    </div>
   )
 })
 ThemeToggle.displayName = 'ThemeToggle'


### PR DESCRIPTION
## Summary
- Replace Headless UI sidebar/dialog usage with native semantic markup
- Replace Headless UI theme listbox with React state and native buttons
- Remove @headlessui/react from package.json and pnpm-lock.yaml

Closes #3106

## Validation
- pnpm validate
- pnpm playwright e2e/visitor.spec.ts e2e/admin/post-crud.spec.ts -g "site theme|create new post via Sidebar"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Sidebar rewritten to a lighter implementation: preserves backdrop dismissal, keyboard shortcut, Escape to close, focus trapping/cycling, and restores focus after close for improved accessibility and reliability.
  * Theme toggle converted to a button-triggered menu with click-outside and Escape handling, clear ARIA attributes, and focus management for better keyboard and screen reader support.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3760?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->