### PR TITLE
fix: prevent duplicate stock urls

### DIFF
--- a/browser-extension/README.md
+++ b/browser-extension/README.md
@@ -202,8 +202,8 @@ No manual configuration required!
 Create a `.env` file in the browser-extension directory:
 
 ```env
-# Backend API URL
-VITE_API_URL=http://localhost:4000/api/posts
+# Backend API endpoint
+VITE_API_ENDPOINT=http://localhost:4000/api/
 
 # Optional: Analytics
 VITE_SENTRY_DNS=your-sentry-dsn

--- a/browser-extension/src/entrypoints/popup/App.tsx
+++ b/browser-extension/src/entrypoints/popup/App.tsx
@@ -1,93 +1,175 @@
 import axios from 'axios'
-import React, { useState, FC, ChangeEvent } from 'react'
+import React, { useEffect, useState, type ChangeEvent, type FC } from 'react'
 
 import { setBookmarkedIcon } from '../../lib/setBookmarkIcon'
 
+import {
+  ALREADY_EXISTS_MESSAGE,
+  FAILED_MESSAGE,
+  FEEDBACK_CLEAR_DELAY_MS,
+  SUCCESS_MESSAGE,
+} from './constants'
 import { useGetPageInfo } from './useGetPageInfo'
+import { buildStockExistsUrl } from './utils/buildStockExistsUrl'
+import { isConflictResponse } from './utils/isConflictResponse'
+import { normalizePopupUrl } from './utils/normalizePopupUrl'
 
 export interface PopupState {
   pageTitle: string
   url: string
 }
 
+interface StockExistsResponse {
+  exists: boolean
+}
+
+type FeedbackMessage =
+  | ''
+  | typeof ALREADY_EXISTS_MESSAGE
+  | typeof FAILED_MESSAGE
+  | typeof SUCCESS_MESSAGE
+
+type StockSaveState = {
+  feedbackMessage: FeedbackMessage
+  isAlreadySaved: boolean
+  isChecked: boolean
+}
+
+const INITIAL_STOCK_SAVE_STATE: StockSaveState = {
+  feedbackMessage: '',
+  isAlreadySaved: false,
+  isChecked: false,
+}
+
 /**
- * Main popup component for NSX extension
- * Allows users to bookmark the current page and share on Twitter
+ * Renders the NSX extension popup and coordinates duplicate-aware page saves.
+ * @returns The popup UI for saving the current tab and composing a tweet.
+ * @example
+ * <App />
  */
 const App: FC = () => {
   const state = useGetPageInfo()
   const [comment, setComment] = useState<string>('')
+  const [stockSaveState, setStockSaveState] = useState<StockSaveState>(
+    INITIAL_STOCK_SAVE_STATE,
+  )
+  const normalizedUrl = normalizePopupUrl(state.url)
+
+  useEffect(() => {
+    const apiUrl = import.meta.env.VITE_API_URL
+
+    if (!apiUrl || !normalizedUrl) {
+      setStockSaveState(INITIAL_STOCK_SAVE_STATE)
+      return undefined
+    }
+
+    let isRequestCanceled = false
+
+    axios
+      .get<StockExistsResponse>(buildStockExistsUrl(apiUrl, normalizedUrl))
+      .then(({ data }) => {
+        if (isRequestCanceled) return
+
+        setStockSaveState({
+          feedbackMessage: data.exists ? ALREADY_EXISTS_MESSAGE : '',
+          isAlreadySaved: data.exists,
+          isChecked: data.exists,
+        })
+
+        if (data.exists) setBookmarkedIcon()
+      })
+      .catch(() => {
+        if (isRequestCanceled) return
+
+        // Existence check failures should not block saving a new page.
+        setStockSaveState(INITIAL_STOCK_SAVE_STATE)
+      })
+
+    return () => {
+      isRequestCanceled = true
+    }
+  }, [normalizedUrl])
 
   /**
-   * Handles checkbox toggle to save current page
-   * Sends page data to backend, updates icon, and shows success message
+   * Shows a temporary result message after save attempts complete.
+   * @param message - The feedback text to display in the result area.
+   * @returns Nothing; React state controls when the message appears and clears.
+   * @example
+   * showTemporaryFeedback(SUCCESS_MESSAGE)
    */
-  const onCheckedHandler = (e: ChangeEvent<HTMLInputElement>): void => {
-    if (!e.target.checked) return
+  const showTemporaryFeedback = (message: FeedbackMessage): void => {
+    setStockSaveState((currentState) => ({
+      ...currentState,
+      feedbackMessage: message,
+    }))
+
+    window.setTimeout(() => {
+      setStockSaveState((currentState) =>
+        currentState.feedbackMessage === message
+          ? { ...currentState, feedbackMessage: '' }
+          : currentState,
+      )
+    }, FEEDBACK_CLEAR_DELAY_MS)
+  }
+
+  /**
+   * Saves the current page when the popup checkbox is checked.
+   * @param event - The checkbox change event from the popup UI.
+   * @returns Nothing; API responses update checkbox, icon, and feedback state.
+   * @example
+   * onCheckedHandler(event)
+   */
+  const onCheckedHandler = (event: ChangeEvent<HTMLInputElement>): void => {
+    if (!event.target.checked) {
+      setStockSaveState((currentState) => ({
+        ...currentState,
+        isChecked: false,
+      }))
+      return
+    }
 
     // Updated to use Vite's import.meta.env instead of process.env
     const apiUrl = import.meta.env.VITE_API_URL
+    setStockSaveState((currentState) => ({
+      ...currentState,
+      isChecked: true,
+    }))
+
+    if (stockSaveState.isAlreadySaved) {
+      setStockSaveState((currentState) => ({
+        ...currentState,
+        feedbackMessage: ALREADY_EXISTS_MESSAGE,
+      }))
+      setBookmarkedIcon()
+      return
+    }
 
     axios
       .post(apiUrl, {
         pageTitle: state.pageTitle,
-        url: state.url.replace(/\/$/, ''),
+        url: normalizedUrl,
       })
       .then(() => {
-        const resultElement = document.querySelector('.result')
-        if (!resultElement) return
-
-        const span = document.createElement('span')
-        span.innerHTML = 'Success!'
-        resultElement.appendChild(span)
-
-        const fadeInEffect = new KeyframeEffect(
-          span,
-          [{ opacity: '0' }, { opacity: '1' }],
-          {
-            duration: 100,
-            fill: 'forwards',
-          },
-        )
-
-        const fadeInAnimation = new Animation(fadeInEffect, document.timeline)
-        fadeInAnimation.play()
-
-        setTimeout(() => {
-          const fadeOutEffect = new KeyframeEffect(
-            span,
-            [{ opacity: '1' }, { opacity: '0' }],
-            {
-              duration: 100,
-              fill: 'forwards',
-            },
-          )
-
-          const fadeOutAnimation = new Animation(
-            fadeOutEffect,
-            document.timeline,
-          )
-          fadeOutAnimation.play()
-
-          fadeOutAnimation.onfinish = () => {
-            span.remove()
-          }
-        }, 1000)
-      })
-      .catch((err: unknown) => {
-        const resultElement = document.querySelector('.result')
-        if (!resultElement) return
-
-        const span = document.createElement('span')
-        span.innerHTML = 'Failed...'
-        resultElement.appendChild(span)
-        setTimeout(() => {
-          span.remove()
-        }, 1000)
-        console.error(JSON.stringify(err))
-      })
-      .then(() => {
+        showTemporaryFeedback(SUCCESS_MESSAGE)
         setBookmarkedIcon()
+      })
+      .catch((error: unknown) => {
+        if (isConflictResponse(error)) {
+          setStockSaveState({
+            feedbackMessage: ALREADY_EXISTS_MESSAGE,
+            isAlreadySaved: true,
+            isChecked: true,
+          })
+          setBookmarkedIcon()
+          return
+        }
+
+        setStockSaveState((currentState) => ({
+          ...currentState,
+          isChecked: false,
+        }))
+        showTemporaryFeedback(FAILED_MESSAGE)
+        console.error(JSON.stringify(error))
       })
   }
 
@@ -99,6 +181,13 @@ const App: FC = () => {
         </div>
         <input
           className="checkbox"
+          aria-label={
+            stockSaveState.isAlreadySaved
+              ? 'Already Exists'
+              : 'Save current page to NSX'
+          }
+          checked={stockSaveState.isChecked}
+          disabled={stockSaveState.isAlreadySaved || !normalizedUrl}
           type="checkbox"
           onChange={onCheckedHandler}
         />
@@ -120,7 +209,11 @@ const App: FC = () => {
         >
           tweet
         </a>
-        <div className="result" />
+        <div className="result">
+          {stockSaveState.feedbackMessage ? (
+            <span>{stockSaveState.feedbackMessage}</span>
+          ) : null}
+        </div>
       </section>
     </main>
   )

--- a/browser-extension/src/entrypoints/popup/App.tsx
+++ b/browser-extension/src/entrypoints/popup/App.tsx
@@ -5,11 +5,13 @@ import { setBookmarkedIcon } from '../../lib/setBookmarkIcon'
 
 import {
   ALREADY_EXISTS_MESSAGE,
+  DEFAULT_API_ENDPOINT,
   FAILED_MESSAGE,
   FEEDBACK_CLEAR_DELAY_MS,
   SUCCESS_MESSAGE,
 } from './constants'
 import { useGetPageInfo } from './useGetPageInfo'
+import { buildPushStockApiUrl } from './utils/buildPushStockApiUrl'
 import { buildStockExistsUrl } from './utils/buildStockExistsUrl'
 import { isConflictResponse } from './utils/isConflictResponse'
 import { normalizePopupUrl } from './utils/normalizePopupUrl'
@@ -56,9 +58,11 @@ const App: FC = () => {
   const normalizedUrl = normalizePopupUrl(state.url)
 
   useEffect(() => {
-    const apiUrl = import.meta.env.VITE_API_URL
+    const pushStockApiUrl = buildPushStockApiUrl(
+      import.meta.env.VITE_API_ENDPOINT || DEFAULT_API_ENDPOINT,
+    )
 
-    if (!apiUrl || !normalizedUrl) {
+    if (!normalizedUrl) {
       setStockSaveState(INITIAL_STOCK_SAVE_STATE)
       return undefined
     }
@@ -66,7 +70,9 @@ const App: FC = () => {
     let isRequestCanceled = false
 
     axios
-      .get<StockExistsResponse>(buildStockExistsUrl(apiUrl, normalizedUrl))
+      .get<StockExistsResponse>(
+        buildStockExistsUrl(pushStockApiUrl, normalizedUrl),
+      )
       .then(({ data }) => {
         if (isRequestCanceled) return
 
@@ -128,8 +134,10 @@ const App: FC = () => {
       return
     }
 
-    // Updated to use Vite's import.meta.env instead of process.env
-    const apiUrl = import.meta.env.VITE_API_URL
+    // Vite injects the shared endpoint during builds; E2E falls back to localhost.
+    const pushStockApiUrl = buildPushStockApiUrl(
+      import.meta.env.VITE_API_ENDPOINT || DEFAULT_API_ENDPOINT,
+    )
     setStockSaveState((currentState) => ({
       ...currentState,
       isChecked: true,
@@ -145,7 +153,7 @@ const App: FC = () => {
     }
 
     axios
-      .post(apiUrl, {
+      .post(pushStockApiUrl, {
         pageTitle: state.pageTitle,
         url: normalizedUrl,
       })

--- a/browser-extension/src/entrypoints/popup/constants.ts
+++ b/browser-extension/src/entrypoints/popup/constants.ts
@@ -1,4 +1,5 @@
 export const ALREADY_EXISTS_MESSAGE = 'Already Exists'
+export const DEFAULT_API_ENDPOINT = 'http://localhost:4000/api/'
 export const FAILED_MESSAGE = 'Failed...'
 export const FEEDBACK_CLEAR_DELAY_MS = 1000
 export const SUCCESS_MESSAGE = 'Success!'

--- a/browser-extension/src/entrypoints/popup/constants.ts
+++ b/browser-extension/src/entrypoints/popup/constants.ts
@@ -1,0 +1,4 @@
+export const ALREADY_EXISTS_MESSAGE = 'Already Exists'
+export const FAILED_MESSAGE = 'Failed...'
+export const FEEDBACK_CLEAR_DELAY_MS = 1000
+export const SUCCESS_MESSAGE = 'Success!'

--- a/browser-extension/src/entrypoints/popup/utils/buildPushStockApiUrl.ts
+++ b/browser-extension/src/entrypoints/popup/utils/buildPushStockApiUrl.ts
@@ -1,0 +1,20 @@
+const API_PATHNAME = '/api'
+const PUSH_STOCK_PATHNAME = '/push_stock'
+
+/**
+ * Builds the stock save URL from the shared VITE_API_ENDPOINT base.
+ * @param apiEndpoint - The configured backend endpoint, with or without `/api`.
+ * @returns The absolute POST /api/push_stock URL.
+ * @example
+ * buildPushStockApiUrl('http://localhost:4000') // => 'http://localhost:4000/api/push_stock'
+ */
+export const buildPushStockApiUrl = (apiEndpoint: string): string => {
+  const endpointUrl = new globalThis.URL(apiEndpoint)
+  const pathnameWithoutTrailingSlash = endpointUrl.pathname.replace(/\/$/, '')
+
+  endpointUrl.pathname = pathnameWithoutTrailingSlash.endsWith(API_PATHNAME)
+    ? `${pathnameWithoutTrailingSlash}${PUSH_STOCK_PATHNAME}`
+    : `${pathnameWithoutTrailingSlash}${API_PATHNAME}${PUSH_STOCK_PATHNAME}`
+
+  return endpointUrl.toString()
+}

--- a/browser-extension/src/entrypoints/popup/utils/buildStockExistsUrl.ts
+++ b/browser-extension/src/entrypoints/popup/utils/buildStockExistsUrl.ts
@@ -1,0 +1,23 @@
+import { normalizePopupUrl } from './normalizePopupUrl'
+
+/**
+ * Builds the duplicate-check endpoint from the existing save endpoint env var.
+ * @param pushStockApiUrl - The configured POST /api/push_stock endpoint.
+ * @param stockUrl - The current page URL to check.
+ * @returns A GET /api/stock/exists URL with the normalized stock URL in query params.
+ * @example
+ * buildStockExistsUrl('https://nsx.test/api/push_stock', 'https://example.com/')
+ */
+export const buildStockExistsUrl = (
+  pushStockApiUrl: string,
+  stockUrl: string,
+): string => {
+  const stockExistsUrl = new globalThis.URL(pushStockApiUrl)
+  stockExistsUrl.pathname = stockExistsUrl.pathname.replace(
+    /\/push_stock\/?$/,
+    '/stock/exists',
+  )
+  stockExistsUrl.searchParams.set('url', normalizePopupUrl(stockUrl))
+
+  return stockExistsUrl.toString()
+}

--- a/browser-extension/src/entrypoints/popup/utils/isConflictResponse.ts
+++ b/browser-extension/src/entrypoints/popup/utils/isConflictResponse.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+/**
+ * Detects duplicate stock responses without depending on backend message text.
+ * @param error - The unknown error value thrown by axios.
+ * @returns Whether the backend responded with HTTP 409 Conflict.
+ * @example
+ * isConflictResponse(error) // => true
+ */
+export const isConflictResponse = (error: unknown): boolean => {
+  return axios.isAxiosError(error) && error.response?.status === 409
+}

--- a/browser-extension/src/entrypoints/popup/utils/normalizePopupUrl.ts
+++ b/browser-extension/src/entrypoints/popup/utils/normalizePopupUrl.ts
@@ -1,0 +1,8 @@
+/**
+ * Normalizes popup URLs before duplicate checks and save requests run.
+ * @param url - The current tab URL.
+ * @returns The URL without one trailing slash.
+ * @example
+ * normalizePopupUrl('https://example.com/') // => 'https://example.com'
+ */
+export const normalizePopupUrl = (url: string): string => url.replace(/\/$/, '')

--- a/browser-extension/src/env.d.ts
+++ b/browser-extension/src/env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface ImportMetaEnv {
-  readonly VITE_API_URL: string
+  readonly VITE_API_ENDPOINT?: string
 }
 
 interface ImportMeta {

--- a/browser-extension/tests/e2e/api-integration.spec.ts
+++ b/browser-extension/tests/e2e/api-integration.spec.ts
@@ -164,8 +164,8 @@ test.describe('Extension API Integration Tests', () => {
     await popupPage.close()
   })
 
-  // Skipped: VITE_API_URL not being built into extension - See https://plane.so (NSX-80)
-  test.skip('uses correct VITE_API_URL from environment', async ({
+  // Skipped: VITE_API_ENDPOINT not being built into extension - See https://plane.so (NSX-80)
+  test.skip('uses correct VITE_API_ENDPOINT from environment', async ({
     context,
     extensionId,
     page,

--- a/browser-extension/tests/e2e/extension-fixture.ts
+++ b/browser-extension/tests/e2e/extension-fixture.ts
@@ -19,6 +19,10 @@ export type ExtensionTestFixtures = {
   extensionId: string
 }
 
+type OpenPopupOptions = {
+  stockExists?: boolean
+}
+
 export const test = base.extend<ExtensionTestFixtures>({
   // Override context to use persistent context with extension loaded
   context: async (
@@ -70,13 +74,28 @@ export const test = base.extend<ExtensionTestFixtures>({
 export { expect } from '@playwright/test'
 
 /**
- * Helper to open extension popup
+ * Opens the extension popup with a deterministic stock existence response.
+ * @param context - The persistent browser context with the extension loaded.
+ * @param extensionId - The loaded extension ID from the service worker URL.
+ * @param options - Optional popup API fixtures, defaulting stock existence to false.
+ * @returns The popup page after the React root is ready.
+ * @example
+ * await openPopup(context, extensionId, { stockExists: true })
  */
 export async function openPopup(
   context: BrowserContext,
   extensionId: string,
+  options: OpenPopupOptions = {},
 ): Promise<Page> {
   const popupPage = await context.newPage()
+  await popupPage.route('**/api/stock/exists**', (route) => {
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ exists: options.stockExists ?? false }),
+    })
+  })
+
   await popupPage.goto(`chrome-extension://${extensionId}/popup.html`)
   await popupPage.waitForLoadState('domcontentloaded')
 

--- a/browser-extension/tests/e2e/popup.spec.ts
+++ b/browser-extension/tests/e2e/popup.spec.ts
@@ -102,6 +102,76 @@ test.describe('Extension Popup UI Tests', () => {
     await popupPage.close()
   })
 
+  test('already stocked page disables save checkbox and shows feedback', async ({
+    context,
+    extensionId,
+    page,
+  }) => {
+    // Arrange
+    const backendReady = await waitForBackendReady()
+    expect(backendReady).toBe(true)
+
+    await page.goto(TestPages.example.url)
+    await page.waitForLoadState('domcontentloaded')
+
+    // Act
+    const popupPage = await openPopup(context, extensionId, {
+      stockExists: true,
+    })
+
+    // Assert
+    const checkbox = popupPage.locator('.checkbox')
+    await expect(checkbox).toBeChecked()
+    await expect(checkbox).toBeDisabled()
+    await expect(popupPage.locator('.result')).toContainText('Already Exists')
+
+    await popupPage.close()
+  })
+
+  test('duplicate save response keeps checkbox checked and shows feedback', async ({
+    context,
+    extensionId,
+    page,
+  }) => {
+    // Arrange
+    const backendReady = await waitForBackendReady()
+    expect(backendReady).toBe(true)
+
+    await page.goto(TestPages.example.url)
+    await page.waitForLoadState('domcontentloaded')
+
+    const popupPage = await context.newPage()
+    await popupPage.route('**/api/stock/exists**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ exists: false }),
+      })
+    })
+    await popupPage.route('**/api/push_stock', (route) => {
+      route.fulfill({
+        status: 409,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Already exists' }),
+      })
+    })
+
+    await popupPage.goto(`chrome-extension://${extensionId}/popup.html`)
+    await popupPage.waitForLoadState('domcontentloaded')
+    await popupPage.waitForSelector('#popup', { timeout: 5000 })
+
+    // Act
+    const checkbox = popupPage.locator('.checkbox')
+    await checkbox.check()
+
+    // Assert
+    await expect(checkbox).toBeChecked()
+    await expect(checkbox).toBeDisabled()
+    await expect(popupPage.locator('.result')).toContainText('Already Exists')
+
+    await popupPage.close()
+  })
+
   // Skipped: Success message not appearing - See https://plane.so (NSX-81)
   test.skip('saves page on checkbox click and shows success message', async ({
     context,

--- a/browser-extension/tests/unit/entrypoints/popup/utils/buildPushStockApiUrl.test.ts
+++ b/browser-extension/tests/unit/entrypoints/popup/utils/buildPushStockApiUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildPushStockApiUrl } from '@/entrypoints/popup/utils/buildPushStockApiUrl'
+
+describe('buildPushStockApiUrl', () => {
+  it('uses the localhost backend fallback endpoint for extension E2E saves', () => {
+    // Arrange
+    const apiEndpoint = 'http://localhost:4000'
+
+    // Act
+    const pushStockApiUrl = buildPushStockApiUrl(apiEndpoint)
+
+    // Assert
+    expect(pushStockApiUrl).toBe('http://localhost:4000/api/push_stock')
+  })
+
+  it('keeps the existing api path when the shared endpoint includes it', () => {
+    // Arrange
+    const apiEndpoint = 'https://nsx.malloc.tokyo/api/'
+
+    // Act
+    const pushStockApiUrl = buildPushStockApiUrl(apiEndpoint)
+
+    // Assert
+    expect(pushStockApiUrl).toBe('https://nsx.malloc.tokyo/api/push_stock')
+  })
+})

--- a/browser-extension/tests/unit/entrypoints/popup/utils/buildStockExistsUrl.test.ts
+++ b/browser-extension/tests/unit/entrypoints/popup/utils/buildStockExistsUrl.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildStockExistsUrl } from '@/entrypoints/popup/utils/buildStockExistsUrl'
+
+describe('buildStockExistsUrl', () => {
+  it('routes popup duplicate checks to the stock exists endpoint', () => {
+    // Arrange
+    const pushStockApiUrl = 'https://nsx.malloc.tokyo/api/push_stock'
+    const currentTabUrl = 'https://example.com/articles?id=1&tag=react'
+
+    // Act
+    const stockExistsUrl = buildStockExistsUrl(pushStockApiUrl, currentTabUrl)
+
+    // Assert
+    expect(stockExistsUrl).toBe(
+      'https://nsx.malloc.tokyo/api/stock/exists?url=https%3A%2F%2Fexample.com%2Farticles%3Fid%3D1%26tag%3Dreact',
+    )
+  })
+
+  it('normalizes a trailing slash before the duplicate lookup', () => {
+    // Arrange
+    const pushStockApiUrl = 'http://localhost:4000/api/push_stock/'
+    const currentTabUrl = 'https://example.com/'
+
+    // Act
+    const stockExistsUrl = buildStockExistsUrl(pushStockApiUrl, currentTabUrl)
+
+    // Assert
+    expect(stockExistsUrl).toBe(
+      'http://localhost:4000/api/stock/exists?url=https%3A%2F%2Fexample.com',
+    )
+  })
+})

--- a/browser-extension/tests/unit/entrypoints/popup/utils/isConflictResponse.test.ts
+++ b/browser-extension/tests/unit/entrypoints/popup/utils/isConflictResponse.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+
+import { isConflictResponse } from '@/entrypoints/popup/utils/isConflictResponse'
+
+describe('isConflictResponse', () => {
+  it('shows duplicate feedback for HTTP 409 axios responses', () => {
+    // Arrange
+    const error = {
+      isAxiosError: true,
+      response: { status: 409 },
+    }
+
+    // Act
+    const isDuplicateResponse = isConflictResponse(error)
+
+    // Assert
+    expect(isDuplicateResponse).toBe(true)
+  })
+
+  it('keeps generic failure feedback for non-conflict axios responses', () => {
+    // Arrange
+    const error = {
+      isAxiosError: true,
+      response: { status: 500 },
+    }
+
+    // Act
+    const isDuplicateResponse = isConflictResponse(error)
+
+    // Assert
+    expect(isDuplicateResponse).toBe(false)
+  })
+})

--- a/browser-extension/tests/unit/entrypoints/popup/utils/normalizePopupUrl.test.ts
+++ b/browser-extension/tests/unit/entrypoints/popup/utils/normalizePopupUrl.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizePopupUrl } from '@/entrypoints/popup/utils/normalizePopupUrl'
+
+describe('normalizePopupUrl', () => {
+  it('treats a trailing slash URL as the same stocked page', () => {
+    // Arrange
+    const currentTabUrl = 'https://example.com/'
+
+    // Act
+    const normalizedUrl = normalizePopupUrl(currentTabUrl)
+
+    // Assert
+    expect(normalizedUrl).toBe('https://example.com')
+  })
+
+  it('keeps a URL without trailing slash unchanged', () => {
+    // Arrange
+    const currentTabUrl = 'https://example.com/articles?id=1'
+
+    // Act
+    const normalizedUrl = normalizePopupUrl(currentTabUrl)
+
+    // Assert
+    expect(normalizedUrl).toBe('https://example.com/articles?id=1')
+  })
+})

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -7,15 +7,61 @@ import { prisma } from '../prisma'
 
 const router: Router = express.Router()
 
+const DUPLICATE_STOCK_MESSAGE = 'Already exists'
+
+/**
+ * Normalizes stock URLs so popup and backend duplicate checks compare the same value.
+ * @param url - The incoming URL value from request body or query string.
+ * @returns
+ * - When url is a string: the URL without one trailing slash
+ * - When url is missing or not a string: an empty string
+ * @example
+ * normalizeStockUrl('https://example.com/') // => 'https://example.com'
+ */
+const normalizeStockUrl = (url: unknown): string => {
+  if (typeof url !== 'string') return ''
+
+  return url.replace(/\/$/, '')
+}
+
+/**
+ * Finds whether a normalized URL is already in the stock table.
+ * @param url - The normalized URL to check.
+ * @returns Whether a matching stock row exists.
+ * @example
+ * await stockUrlExists('https://example.com') // => false
+ */
+const stockUrlExists = async (url: string): Promise<boolean> => {
+  const existingStock = await prisma.stock.findFirst({
+    where: { url },
+  })
+
+  return Boolean(existingStock)
+}
+
 router.post(
   '/push_stock',
   async (req: Request, res: Response, next: NextFunction) => {
     const body = req.body
+    const normalizedUrl = normalizeStockUrl(body.url)
+
     try {
+      // Missing URLs cannot be compared, so reject before touching the database.
+      if (!normalizedUrl) {
+        res.status(400).json({ message: 'URL is required' })
+        return
+      }
+
+      // A duplicate page should look saved in the extension instead of creating a row.
+      if (await stockUrlExists(normalizedUrl)) {
+        res.status(409).json({ message: DUPLICATE_STOCK_MESSAGE })
+        return
+      }
+
       const stock = await prisma.stock.create({
         data: {
           pageTitle: body.pageTitle,
-          url: body.url,
+          url: normalizedUrl,
         },
       })
       res.status(201).json(stock)
@@ -29,6 +75,23 @@ router.post(
 router.get('/stocklist', async (_req, res) => {
   const stockList = await prisma.stock.findMany()
   res.status(200).json(stockList)
+})
+
+router.get('/stock/exists', async (req, res, next) => {
+  const normalizedUrl = normalizeStockUrl(req.query.url)
+
+  try {
+    // The popup needs a concrete URL to answer whether this page is already saved.
+    if (!normalizedUrl) {
+      res.status(400).json({ message: 'URL is required' })
+      return
+    }
+
+    res.status(200).json({ exists: await stockUrlExists(normalizedUrl) })
+  } catch (error) {
+    Logger.error(error)
+    next(error)
+  }
 })
 
 router.delete('/stock/:id', isAuthorized, async (req, res) => {

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -8,6 +8,9 @@ import { prisma } from '../prisma'
 const router: Router = express.Router()
 
 const DUPLICATE_STOCK_MESSAGE = 'Already exists'
+const INVALID_URL_MESSAGE = 'URL is invalid'
+const TITLE_REQUIRED_MESSAGE = 'Title is required'
+const URL_REQUIRED_MESSAGE = 'URL is required'
 
 /**
  * Normalizes stock URLs so popup and backend duplicate checks compare the same value.
@@ -21,7 +24,36 @@ const DUPLICATE_STOCK_MESSAGE = 'Already exists'
 const normalizeStockUrl = (url: unknown): string => {
   if (typeof url !== 'string') return ''
 
-  return url.replace(/\/$/, '')
+  return url.trim().replace(/\/$/, '')
+}
+
+/**
+ * Normalizes stock titles so empty or whitespace-only values are rejected.
+ * @param title - The incoming page title value from the request body.
+ * @returns The trimmed page title, or an empty string for invalid input.
+ * @example
+ * normalizeStockTitle(' Example ') // => 'Example'
+ */
+const normalizeStockTitle = (title: unknown): string => {
+  if (typeof title !== 'string') return ''
+
+  return title.trim()
+}
+
+/**
+ * Checks URL syntax before saving extension-submitted pages.
+ * @param url - The normalized URL string to validate.
+ * @returns Whether the URL can be parsed by the platform URL parser.
+ * @example
+ * isValidStockUrl('https://example.com') // => true
+ */
+const isValidStockUrl = (url: string): boolean => {
+  try {
+    new globalThis.URL(url)
+    return true
+  } catch {
+    return false
+  }
 }
 
 /**
@@ -43,24 +75,35 @@ router.post(
   '/push_stock',
   async (req: Request, res: Response, next: NextFunction) => {
     const body = req.body
+    const pageTitle = normalizeStockTitle(body.pageTitle ?? body.title)
     const normalizedUrl = normalizeStockUrl(body.url)
 
     try {
-      // Missing URLs cannot be compared, so reject before touching the database.
+      // Missing inputs are rejected before touching the database.
       if (!normalizedUrl) {
-        res.status(400).json({ message: 'URL is required' })
+        res.status(400).json({ error: URL_REQUIRED_MESSAGE })
+        return
+      }
+
+      if (!pageTitle) {
+        res.status(400).json({ error: TITLE_REQUIRED_MESSAGE })
+        return
+      }
+
+      if (!isValidStockUrl(normalizedUrl)) {
+        res.status(400).json({ error: INVALID_URL_MESSAGE })
         return
       }
 
       // A duplicate page should look saved in the extension instead of creating a row.
       if (await stockUrlExists(normalizedUrl)) {
-        res.status(409).json({ message: DUPLICATE_STOCK_MESSAGE })
+        res.status(409).json({ error: DUPLICATE_STOCK_MESSAGE })
         return
       }
 
       const stock = await prisma.stock.create({
         data: {
-          pageTitle: body.pageTitle,
+          pageTitle,
           url: normalizedUrl,
         },
       })
@@ -83,7 +126,7 @@ router.get('/stock/exists', async (req, res, next) => {
   try {
     // The popup needs a concrete URL to answer whether this page is already saved.
     if (!normalizedUrl) {
-      res.status(400).json({ message: 'URL is required' })
+      res.status(400).json({ error: URL_REQUIRED_MESSAGE })
       return
     }
 


### PR DESCRIPTION
## Summary
- reject duplicate stock URLs in `POST /api/push_stock` with 409 Conflict
- add `GET /api/stock/exists` for popup duplicate checks
- show "Already Exists" feedback and disable the popup checkbox for saved pages
- add popup URL helper unit tests and duplicate-state E2E coverage

Closes #3721

## Validation
- `pnpm validate`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm --dir browser-extension lint`
- `pnpm --dir browser-extension typecheck`
- `pnpm --dir browser-extension test:coverage`
- `pnpm --dir browser-extension build`
- `pnpm --dir browser-extension test`
- local API check: `exists=false -> 201 -> exists=true -> 409`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Duplicate-aware page saving with real-time existence checks and clear feedback for success, duplicates, and errors
  * Checkbox reflects save state (checked/disabled) and updates based on existence checks
  * Improved URL normalization for consistent save/lookups

* **Tests**
  * Added unit and end-to-end tests covering duplicate detection, conflict handling, and URL normalization

* **Documentation**
  * Updated extension README example for backend endpoint configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3761?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->