### PR TITLE
fix: prevent login user enumeration

### DIFF
--- a/@types/response.d.ts
+++ b/@types/response.d.ts
@@ -1,11 +1,14 @@
 // API Response Parameters
 declare namespace Res {
-  // Use to when user failed something within intended aplication behavior e.g. failed login by miss type password
-  declare type failedMessage = { failed: string }
+  declare type AuthError = {
+    error: 'Invalid credentials'
+    code: 'AUTHENTICATION_FAILED'
+  }
+
   /**
    * POST /api/login
    */
-  declare type Login = User | Res.failedMessag
+  declare type Login = User
 
   /**
    * POST: /api/signup
@@ -54,5 +57,6 @@ declare namespace Res {
    */
   declare type Error = {
     error: string
+    code?: string
   }
 }

--- a/e2e/admin/authentication.spec.ts
+++ b/e2e/admin/authentication.spec.ts
@@ -78,10 +78,9 @@ test.describe('JWT Expiration', () => {
     const response = await responsePromise
 
     // Check if login was successful
+    expect(response.status()).toBe(200)
     const responseBody = await response.json()
-    if (responseBody.failed) {
-      throw new Error(`Login failed: ${responseBody.failed}`)
-    }
+    expect(responseBody.name).toBe('John Doe')
 
     // Wait for navigation and verify login
     await page.waitForLoadState('networkidle')
@@ -133,10 +132,9 @@ test.describe('JWT Expiration', () => {
     const loginResponse = await loginResponsePromise
 
     // Check if login was successful
+    expect(loginResponse.status()).toBe(200)
     const responseBody = await loginResponse.json()
-    if (responseBody.failed) {
-      throw new Error(`Login failed: ${responseBody.failed}`)
-    }
+    expect(responseBody.name).toBe('John Doe')
 
     // Wait for navigation and verify login
     await page.waitForLoadState('networkidle')

--- a/e2e/admin/hover-color-preference.spec.ts
+++ b/e2e/admin/hover-color-preference.spec.ts
@@ -26,10 +26,9 @@ test.describe('Hover Color Preference Toggle', () => {
     await page.getByTestId('submit-btn').click()
     const loginResponse = await loginResponsePromise
 
+    expect(loginResponse.status()).toBe(200)
     const responseBody = await loginResponse.json()
-    if (responseBody.failed) {
-      throw new Error(`Login failed: ${responseBody.failed}`)
-    }
+    expect(responseBody.name).toBe('John Doe')
 
     await page.waitForLoadState('networkidle')
 

--- a/e2e/admin/login-logout.spec.ts
+++ b/e2e/admin/login-logout.spec.ts
@@ -18,14 +18,51 @@ test.describe('login & logout', () => {
     await expect(page.getByTestId('login-link')).toBeVisible()
   })
 
-  test('failed login with incorrect user/password', async ({ page }) => {
+  test('returns the same invalid credentials response for unknown users and wrong passwords', async ({
+    page,
+  }) => {
+    // Arrange
     await page.goto('http://localhost:3010')
     await page.keyboard.press('x')
     await page.click('[data-testid=login-link]')
     await page.fill('[data-testid=name-input]', 'wefjweiofjwie')
     await page.fill('[data-testid=password-input]', 'wfjweoifjio23r03')
+    const unknownUserResponsePromise = page.waitForResponse('**/login')
+
+    // Act
     await page.click('[data-testid=submit-btn]')
-    await expect(page.getByTestId('snackbar')).toHaveText('User does not exist')
+    const unknownUserResponse = await unknownUserResponsePromise
+
+    // Assert
+    expect(unknownUserResponse.status()).toBe(401)
+    await expect(page.getByTestId('snackbar').last()).toHaveText(
+      'Invalid credentials',
+    )
+    await expect(page).toHaveURL('http://localhost:3010/login')
+    expect(await unknownUserResponse.json()).toEqual({
+      error: 'Invalid credentials',
+      code: 'AUTHENTICATION_FAILED',
+    })
+
+    // Arrange
+    await page.fill('[data-testid=name-input]', 'John Doe')
+    await page.fill('[data-testid=password-input]', 'wfjweoifjio23r03')
+    const wrongPasswordResponsePromise = page.waitForResponse('**/login')
+
+    // Act
+    await page.click('[data-testid=submit-btn]')
+    const wrongPasswordResponse = await wrongPasswordResponsePromise
+
+    // Assert
+    expect(wrongPasswordResponse.status()).toBe(401)
+    await expect(page.getByTestId('snackbar').last()).toHaveText(
+      'Invalid credentials',
+    )
+    await expect(page).toHaveURL('http://localhost:3010/login')
+    expect(await wrongPasswordResponse.json()).toEqual({
+      error: 'Invalid credentials',
+      code: 'AUTHENTICATION_FAILED',
+    })
   })
 
   test('successful Logout', async ({ authenticated: page }) => {

--- a/e2e/admin/profile-update.spec.ts
+++ b/e2e/admin/profile-update.spec.ts
@@ -24,10 +24,9 @@ test.describe('Profile Update', () => {
     await page.getByTestId('submit-btn').click()
     const loginResponse = await loginResponsePromise
 
+    expect(loginResponse.status()).toBe(200)
     const responseBody = await loginResponse.json()
-    if (responseBody.failed) {
-      throw new Error(`Login failed: ${responseBody.failed}`)
-    }
+    expect(responseBody.name).toBe('John Doe')
 
     await page.waitForLoadState('networkidle')
 
@@ -64,7 +63,7 @@ test.describe('Profile Update', () => {
     await expect(nameInput).toHaveValue('Jane Smith')
   })
 
-  test('should update password successfully and verify login with new password', async ({
+  test('updates password and rejects the old password after logout', async ({
     page,
   }) => {
     // Login with original credentials
@@ -112,28 +111,37 @@ test.describe('Profile Update', () => {
     await page.goto('http://localhost:3010')
     await page.waitForLoadState('networkidle')
 
-    // Try login with old password (should fail)
+    // Arrange
     await page.keyboard.press('x')
     await page.getByTestId('login-link').click()
     await page.getByTestId('name-input').fill('John Doe')
     await page.getByTestId('password-input').fill('popcoon')
-
     const failedLoginPromise = page.waitForResponse('**/login')
+
+    // Act
     await page.getByTestId('submit-btn').click()
     const failedLoginResponse = await failedLoginPromise
     const failedBody = await failedLoginResponse.json()
-    expect(failedBody.failed).toBeTruthy()
 
-    // Login with new password (should succeed)
+    // Assert
+    expect(failedLoginResponse.status()).toBe(401)
+    expect(failedBody).toEqual({
+      error: 'Invalid credentials',
+      code: 'AUTHENTICATION_FAILED',
+    })
+
+    // Arrange
     await page.getByTestId('name-input').fill('John Doe')
     await page.getByTestId('password-input').fill('newpassword123')
-
     const successLoginPromise = page.waitForResponse('**/login')
+
+    // Act
     await page.getByTestId('submit-btn').click()
     const successLoginResponse = await successLoginPromise
     const successBody = await successLoginResponse.json()
 
-    expect(successBody.failed).toBeUndefined()
+    // Assert
+    expect(successLoginResponse.status()).toBe(200)
     expect(successBody.name).toBe('John Doe')
 
     await page.waitForLoadState('networkidle')
@@ -196,7 +204,7 @@ test.describe('Profile Update', () => {
     const loginResponse = await loginResponsePromise
     const loginBody = await loginResponse.json()
 
-    expect(loginBody.failed).toBeUndefined()
+    expect(loginResponse.status()).toBe(200)
     expect(loginBody.name).toBe('Alice Johnson')
 
     await page.waitForLoadState('networkidle')

--- a/openapi_v3.json
+++ b/openapi_v3.json
@@ -157,7 +157,28 @@
             "description": "OK",
             "content": {
               "application/json": {
-                "schema": { "$ref": "#/components/schemas/Author" }
+                "schema": { "$ref": "#/components/schemas/UserPublic" }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid request body",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string",
+                      "example": "Invalid request body"
+                    },
+                    "code": {
+                      "type": "string",
+                      "example": "VALIDATION_ERROR"
+                    }
+                  },
+                  "required": ["error", "code"]
+                }
               }
             }
           },
@@ -323,6 +344,27 @@
             "format": "date-time"
           }
         }
+      },
+      "UserPublic": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "format": "int64"
+          },
+          "name": {
+            "type": "string"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": ["id", "name", "createdAt", "updatedAt"]
       },
       "Post": {
         "type": "object",

--- a/openapi_v3.json
+++ b/openapi_v3.json
@@ -157,14 +157,27 @@
             "description": "OK",
             "content": {
               "application/json": {
+                "schema": { "$ref": "#/components/schemas/Author" }
+              }
+            }
+          },
+          "401": {
+            "description": "Invalid credentials",
+            "content": {
+              "application/json": {
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "failed": {
+                    "error": {
                       "type": "string",
-                      "example": "User does not exist"
+                      "example": "Invalid credentials"
+                    },
+                    "code": {
+                      "type": "string",
+                      "example": "AUTHENTICATION_FAILED"
                     }
-                  }
+                  },
+                  "required": ["error", "code"]
                 }
               }
             }

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -20,6 +20,8 @@ const AUTHENTICATION_SERVICE_ERROR_MESSAGE =
   'Authentication service temporarily unavailable'
 const DUMMY_PASSWORD_HASH =
   '$2b$10$PDIcmRmxvgVeIaa/c9AWiu4wRQD7EwBjczFqVDjgMtsj4.To0W5aC'
+const INVALID_LOGIN_REQUEST_CODE = 'VALIDATION_ERROR'
+const INVALID_LOGIN_REQUEST_MESSAGE = 'Invalid request body'
 const LOGIN_WINDOW_MS = 15 * 60 * 1000
 const LOGIN_MAX_ATTEMPTS = 5
 const isProd = process.env.NODE_ENV === 'production'
@@ -89,6 +91,25 @@ const sendAuthenticationFailure = (
   })
 }
 
+/**
+ * Sends the public validation response for malformed login requests.
+ *
+ * Called by `/api/login` after the dummy bcrypt comparison has run, so invalid
+ * bodies still avoid a cheap early exit while using the correct HTTP status.
+ *
+ * @param res - Express response used to return the validation error payload.
+ * @returns Nothing; the response is completed with status 400.
+ * @example sendInvalidLoginRequest(res)
+ */
+const sendInvalidLoginRequest = (
+  res: Response<Res.Login | Res.AuthError | Res.Error>,
+): void => {
+  res.status(400).json({
+    error: INVALID_LOGIN_REQUEST_MESSAGE,
+    code: INVALID_LOGIN_REQUEST_CODE,
+  })
+}
+
 router.get(
   '/user_count',
   async (_req: Request, res: Response<Res.GetUserCount>) => {
@@ -153,14 +174,14 @@ router.post(
     const password = normalizeLoginPassword(body?.password)
 
     try {
-      // Malformed login bodies use the same public response as bad credentials.
+      // Malformed bodies still run bcrypt but return the validation status.
       if (!(name && password)) {
         await bcrypt.compare(
           password || 'missing-password',
           DUMMY_PASSWORD_HASH,
         )
-        Logger.warn('Failed login attempt')
-        sendAuthenticationFailure(res)
+        Logger.warn('Invalid login payload')
+        sendInvalidLoginRequest(res)
         return
       }
 

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -13,6 +13,13 @@ import { prisma } from '../prisma'
 
 const router: Router = express.Router()
 
+const AUTHENTICATION_FAILED_CODE = 'AUTHENTICATION_FAILED'
+const AUTHENTICATION_FAILED_MESSAGE = 'Invalid credentials'
+const AUTHENTICATION_SERVICE_ERROR_CODE = 'AUTHENTICATION_SERVICE_ERROR'
+const AUTHENTICATION_SERVICE_ERROR_MESSAGE =
+  'Authentication service temporarily unavailable'
+const DUMMY_PASSWORD_HASH =
+  '$2b$10$PDIcmRmxvgVeIaa/c9AWiu4wRQD7EwBjczFqVDjgMtsj4.To0W5aC'
 const LOGIN_WINDOW_MS = 15 * 60 * 1000
 const LOGIN_MAX_ATTEMPTS = 5
 const isProd = process.env.NODE_ENV === 'production'
@@ -31,6 +38,55 @@ const loginLimiter: RequestHandler = isProd
 interface SignupRequest {
   name: string
   password: string
+}
+
+/**
+ * Converts a submitted login name into the database lookup value.
+ *
+ * Called only by the login endpoint before querying Prisma, so malformed
+ * bodies are handled like any other failed credential attempt.
+ *
+ * @param name - Raw `req.body.name` value from the login form.
+ * @returns Trimmed user name, or an empty string when the value is invalid.
+ * @example normalizeLoginName(' John Doe ') // 'John Doe'
+ */
+const normalizeLoginName = (name: unknown): string => {
+  if (typeof name !== 'string') return ''
+  return name.trim()
+}
+
+/**
+ * Converts a submitted login password into the bcrypt comparison value.
+ *
+ * Called only by the login endpoint, and intentionally keeps whitespace
+ * because passwords can legally contain leading or trailing spaces.
+ *
+ * @param password - Raw `req.body.password` value from the login form.
+ * @returns Password string, or an empty string when the value is invalid.
+ * @example normalizeLoginPassword(' secret ') // ' secret '
+ */
+const normalizeLoginPassword = (password: unknown): string => {
+  if (typeof password !== 'string') return ''
+  return password
+}
+
+/**
+ * Sends the public login failure response shared by every credential failure.
+ *
+ * Called by `/api/login` whenever the username is unknown, the password is
+ * wrong, or the submitted body is malformed.
+ *
+ * @param res - Express response used to return the failed login payload.
+ * @returns Nothing; the response is completed with status 401.
+ * @example sendAuthenticationFailure(res)
+ */
+const sendAuthenticationFailure = (
+  res: Response<Res.Login | Res.AuthError | Res.Error>,
+): void => {
+  res.status(401).json({
+    error: AUTHENTICATION_FAILED_MESSAGE,
+    code: AUTHENTICATION_FAILED_CODE,
+  })
 }
 
 router.get(
@@ -89,30 +145,53 @@ router.post('/signup', signupHandler)
 router.post(
   '/login',
   loginLimiter,
-  async ({ body }: Request, res: Response) => {
-    const user = await prisma.user.findFirst({
-      where: { name: body.name },
-    })
-    if (user) {
-      const isValidPassword = await bcrypt.compare(body.password, user.password)
+  async (
+    { body }: Request,
+    res: Response<Res.Login | Res.AuthError | Res.Error>,
+  ) => {
+    const name = normalizeLoginName(body?.name)
+    const password = normalizeLoginPassword(body?.password)
 
-      if (isValidPassword) {
-        const token: JWTtoken = generateAccessToken(user)
-        res.cookie('token', token, getCookieOptions(token))
-        // Return user without password
-        res.status(200).json({
-          id: user.id,
-          name: user.name,
-          createdAt: user.createdAt,
-          updatedAt: user.updatedAt,
-        })
-      } else {
-        Logger.warn('Invalid Password')
-        res.status(200).json({ failed: 'Invalid Password' }) // this is bad practice in real world product. Because 'Invalid Password' imply exists user that you input at the moment.
+    try {
+      // Malformed login bodies use the same public response as bad credentials.
+      if (!(name && password)) {
+        await bcrypt.compare(
+          password || 'missing-password',
+          DUMMY_PASSWORD_HASH,
+        )
+        Logger.warn('Failed login attempt')
+        sendAuthenticationFailure(res)
+        return
       }
-    } else {
-      Logger.warn('User does not exist')
-      res.status(200).json({ failed: 'User does not exist' }) // this also bad practice in real world product Same reason.
+
+      const user = await prisma.user.findFirst({
+        where: { name },
+      })
+      const passwordHash = user?.password ?? DUMMY_PASSWORD_HASH
+      const isValidPassword = await bcrypt.compare(password, passwordHash)
+
+      // Unknown users and wrong passwords must be indistinguishable to callers.
+      if (!(user && isValidPassword)) {
+        Logger.warn('Failed login attempt')
+        sendAuthenticationFailure(res)
+        return
+      }
+
+      const token: JWTtoken = generateAccessToken(user)
+      res.cookie('token', token, getCookieOptions(token))
+      // Return user without password.
+      res.status(200).json({
+        id: user.id,
+        name: user.name,
+        createdAt: user.createdAt,
+        updatedAt: user.updatedAt,
+      })
+    } catch (error) {
+      Logger.error(error)
+      res.status(500).json({
+        error: AUTHENTICATION_SERVICE_ERROR_MESSAGE,
+        code: AUTHENTICATION_SERVICE_ERROR_CODE,
+      })
     }
   },
 )

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -21,6 +21,48 @@ interface FormInput extends FieldValues {
 }
 
 const LOGIN_FAILED_MESSAGE = 'Invalid credentials'
+const LOGIN_SERVICE_ERROR_MESSAGE =
+  'Authentication service temporarily unavailable'
+
+/**
+ * Checks whether an unknown RTK Query error value can be inspected by key.
+ *
+ * Called only by the login error formatter before reading response metadata.
+ *
+ * @param value - Unknown value returned from RTK Query.
+ * @returns True when the value is a non-null object.
+ * @example isRecord({ status: 401 }) // true
+ */
+const isRecord = (value: unknown): value is Record<string, unknown> => {
+  return typeof value === 'object' && value !== null
+}
+
+/**
+ * Converts RTK Query login failures into user-facing snackbar text.
+ *
+ * Called by `onSubmit` after `loginReqest` returns an error result; credential
+ * failures stay generic while service failures keep a distinct message.
+ *
+ * @param error - RTK Query error object from the login mutation.
+ * @returns Message safe to show in the login snackbar.
+ * @example getLoginErrorMessage({ status: 401, data: { code: 'AUTHENTICATION_FAILED' } })
+ */
+const getLoginErrorMessage = (error: unknown): string => {
+  const errorRecord = isRecord(error) ? error : null
+  const errorData = isRecord(errorRecord?.data) ? errorRecord.data : null
+
+  // Only explicit credential failures use the account-safe generic message.
+  if (
+    errorRecord?.status === 401 &&
+    errorData?.code === 'AUTHENTICATION_FAILED'
+  ) {
+    return LOGIN_FAILED_MESSAGE
+  }
+
+  // Server-side auth outages should not look like bad credentials.
+  if (typeof errorData?.error === 'string') return errorData.error
+  return LOGIN_SERVICE_ERROR_MESSAGE
+}
 
 const Login: React.FC = memo(() => {
   const navigate = useNavigate()
@@ -41,7 +83,13 @@ const Login: React.FC = memo(() => {
 
     // Login failures are intentionally generic to avoid account discovery.
     if ('error' in res && res.error) {
-      dispatch(enqueSnackbar({ color: 'red', message: LOGIN_FAILED_MESSAGE }))
+      console.error('Login request failed:', res.error)
+      dispatch(
+        enqueSnackbar({
+          color: 'red',
+          message: getLoginErrorMessage(res.error),
+        }),
+      )
       return
     }
 

--- a/src/pages/Login/index.tsx
+++ b/src/pages/Login/index.tsx
@@ -8,7 +8,6 @@ import Button from '@/src/components/Button'
 import Input from '@/src/components/Input/Input'
 import Layout from '@/src/components/Layout'
 
-import { assertCast } from '../../../lib/assertCast'
 import { userAccountValidator } from '../../../validator'
 import { login } from '../../redux/adminSlice'
 import { API } from '../../redux/API'
@@ -20,6 +19,8 @@ interface FormInput extends FieldValues {
   name: User['name']
   password: string
 }
+
+const LOGIN_FAILED_MESSAGE = 'Invalid credentials'
 
 const Login: React.FC = memo(() => {
   const navigate = useNavigate()
@@ -37,13 +38,15 @@ const Login: React.FC = memo(() => {
       name: data.name,
       password: data.password,
     })
+
+    // Login failures are intentionally generic to avoid account discovery.
+    if ('error' in res && res.error) {
+      dispatch(enqueSnackbar({ color: 'red', message: LOGIN_FAILED_MESSAGE }))
+      return
+    }
+
     if (isSuccess(res) && 'data' in res) {
       const data = res.data
-      if ('failed' in data) {
-        assertCast<Res.failedMessage>(data)
-        dispatch(enqueSnackbar({ color: 'red', message: data.failed }))
-        return // missing username or pass, onemore time!
-      }
 
       // Login SuccessFul!
       dispatch(login(data))

--- a/src/redux/API.ts
+++ b/src/redux/API.ts
@@ -19,6 +19,21 @@ const baseQuery = fetchBaseQuery({
   },
 })
 
+/**
+ * Detects requests where a 401 is expected to be handled by the caller.
+ *
+ * Called from the shared RTK Query base query before dispatching a logout, so
+ * failed login attempts can show a form error instead of redirecting home.
+ *
+ * @param args - RTK Query request argument passed to `fetchBaseQuery`.
+ * @returns True when the request targets the login endpoint.
+ * @example isLoginRequest({ url: 'login' }) // true
+ */
+const isLoginRequest = (args: string | FetchArgs): boolean => {
+  const url = typeof args === 'string' ? args : args.url
+  return url === 'login' || url.endsWith('/login')
+}
+
 const baseQueryWithReauth: BaseQueryFn<
   string | FetchArgs,
   unknown,
@@ -26,8 +41,8 @@ const baseQueryWithReauth: BaseQueryFn<
 > = async (args, api, extraOptions) => {
   const result = await baseQuery(args, api, extraOptions)
 
-  // Handle 401 unauthorized responses
-  if (result.error && result.error.status === 401) {
+  // Failed login stays on the login form; other 401 responses end the session.
+  if (result.error && result.error.status === 401 && !isLoginRequest(args)) {
     // Dispatch logout action to update Redux state
     api.dispatch(logout())
 


### PR DESCRIPTION
## Summary
- return the same 401 `Invalid credentials` payload for unknown users, wrong passwords, and malformed login bodies
- run bcrypt comparison against a fixed dummy hash when no user is found to reduce timing differences
- keep login 401 responses on the form and update E2E/OpenAPI/types to remove the old `failed` login contract

Closes #3588

## Validation
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm build
- pnpm server:build
- pnpm playwright e2e/admin/login-logout.spec.ts e2e/admin/profile-update.spec.ts
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized authentication error payloads and status codes for consistent, secure responses.
  * Hardened login failure handling to reduce credential-enumeration risk.

* **New Features**
  * Clearer login UX: explicit success notification and redirect on successful sign-in; clearer error messaging for failed attempts.

* **Tests**
  * Updated end-to-end tests to assert the refined login response shape and status codes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3762?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->