### PR TITLE
fix: validate api request bodies with zod

### DIFF
--- a/@types/request.d.ts
+++ b/@types/request.d.ts
@@ -37,7 +37,6 @@ declare namespace Req {
    */
   declare interface CreatePost {
     title: Post['title']
-    author: User
     body: Post['body']
   }
 
@@ -47,7 +46,6 @@ declare namespace Req {
   declare interface UpdatePost {
     id: Post['id']
     title: Post['title']
-    author: User
     body: Post['body']
   }
 }

--- a/@types/response.d.ts
+++ b/@types/response.d.ts
@@ -5,6 +5,12 @@ declare namespace Res {
     code: 'AUTHENTICATION_FAILED'
   }
 
+  declare type ValidationIssue = {
+    field: string
+    message: string
+    code: string
+  }
+
   /**
    * POST /api/login
    */
@@ -58,5 +64,6 @@ declare namespace Res {
   declare type Error = {
     error: string
     code?: string
+    details?: Res.ValidationIssue[]
   }
 }

--- a/e2e/admin/api-validation.spec.ts
+++ b/e2e/admin/api-validation.spec.ts
@@ -1,0 +1,194 @@
+import { exec as execCb } from 'node:child_process'
+import util from 'node:util'
+
+import { expect } from '@playwright/test'
+
+import { test } from '../helper'
+
+const exec = util.promisify(execCb)
+const API_BASE_URL = 'http://localhost:4000/api'
+
+test.beforeAll(async () => {
+  await exec('PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset')
+})
+
+test.describe('API request validation', () => {
+  test('rejects invalid authenticated write bodies before database writes', async ({
+    authenticated: page,
+  }) => {
+    await page.waitForLoadState('networkidle')
+
+    // Arrange
+    const invalidPostPayload = {
+      title: '',
+      body: 'Valid body',
+    }
+
+    // Act
+    const createPostResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/create`, {
+        data: invalidPostPayload,
+      })
+    const createPostBody = (await createPostResponse.json()) as Res.Error
+
+    // Assert
+    expect(createPostResponse.status()).toBe(400)
+    expect(createPostBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'title',
+          message: 'Title is required',
+          code: 'too_small',
+        },
+      ],
+    })
+
+    // Arrange
+    const invalidProfilePayload = {
+      name: 'abc',
+    }
+
+    // Act
+    const profileResponse = await page
+      .context()
+      .request.patch(`${API_BASE_URL}/profile`, {
+        data: invalidProfilePayload,
+      })
+    const profileBody = (await profileResponse.json()) as Res.Error
+
+    // Assert
+    expect(profileResponse.status()).toBe(400)
+    expect(profileBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'name',
+          message: 'Name must be at least 4 characters long',
+          code: 'too_small',
+        },
+      ],
+    })
+
+    // Arrange
+    const invalidTweetPayload = {
+      text: '',
+    }
+
+    // Act
+    const tweetResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/tweet`, {
+        data: invalidTweetPayload,
+      })
+    const tweetBody = (await tweetResponse.json()) as Res.Error
+
+    // Assert
+    expect(tweetResponse.status()).toBe(400)
+    expect(tweetBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'text',
+          message: 'Tweet text is required',
+          code: 'too_small',
+        },
+      ],
+    })
+  })
+
+  test('rejects invalid public integration bodies with structured details', async ({
+    page,
+  }) => {
+    // Arrange
+    const invalidSignupPayload = {
+      name: 'Valid User',
+      password: 'short',
+    }
+
+    // Act
+    const signupResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/signup`, {
+        data: invalidSignupPayload,
+      })
+    const signupBody = (await signupResponse.json()) as Res.Error
+
+    // Assert
+    expect(signupResponse.status()).toBe(400)
+    expect(signupBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'password',
+          message: 'Password must be at least 7 characters long',
+          code: 'too_small',
+        },
+      ],
+    })
+
+    // Arrange
+    const invalidTranslatePayload = {
+      text: 'a'.repeat(5_001),
+    }
+
+    // Act
+    const translateResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/translate`, {
+        data: invalidTranslatePayload,
+      })
+    const translateBody = (await translateResponse.json()) as Res.Error
+
+    // Assert
+    expect(translateResponse.status()).toBe(400)
+    expect(translateBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'text',
+          message: 'Text is too long',
+          code: 'too_big',
+        },
+      ],
+    })
+
+    // Arrange
+    const invalidStockPayload = {
+      pageTitle: 'Readable page',
+      url: 'not-a-url',
+    }
+
+    // Act
+    const stockResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/push_stock`, {
+        data: invalidStockPayload,
+      })
+    const stockBody = (await stockResponse.json()) as Res.Error
+
+    // Assert
+    expect(stockResponse.status()).toBe(400)
+    expect(stockBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'url',
+          message: 'URL is invalid',
+          code: 'invalid_format',
+        },
+      ],
+    })
+  })
+})
+
+test.afterAll(async () => {
+  await exec('PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset')
+})

--- a/e2e/admin/api-validation.spec.ts
+++ b/e2e/admin/api-validation.spec.ts
@@ -99,6 +99,35 @@ test.describe('API request validation', () => {
         },
       ],
     })
+
+    // Arrange
+    const invalidTranslatePayload = {
+      from: 'ja',
+      text: 'a'.repeat(5_001),
+      to: 'en',
+    }
+
+    // Act
+    const translateResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/translate`, {
+        data: invalidTranslatePayload,
+      })
+    const translateBody = (await translateResponse.json()) as Res.Error
+
+    // Assert
+    expect(translateResponse.status()).toBe(400)
+    expect(translateBody).toEqual({
+      error: 'Validation failed',
+      code: 'VALIDATION_ERROR',
+      details: [
+        {
+          field: 'text',
+          message: 'Text is too long',
+          code: 'too_big',
+        },
+      ],
+    })
   })
 
   test('rejects invalid public integration bodies with structured details', async ({
@@ -128,33 +157,6 @@ test.describe('API request validation', () => {
           field: 'password',
           message: 'Password must be at least 7 characters long',
           code: 'too_small',
-        },
-      ],
-    })
-
-    // Arrange
-    const invalidTranslatePayload = {
-      text: 'a'.repeat(5_001),
-    }
-
-    // Act
-    const translateResponse = await page
-      .context()
-      .request.post(`${API_BASE_URL}/translate`, {
-        data: invalidTranslatePayload,
-      })
-    const translateBody = (await translateResponse.json()) as Res.Error
-
-    // Assert
-    expect(translateResponse.status()).toBe(400)
-    expect(translateBody).toEqual({
-      error: 'Validation failed',
-      code: 'VALIDATION_ERROR',
-      details: [
-        {
-          field: 'text',
-          message: 'Text is too long',
-          code: 'too_big',
         },
       ],
     })

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -42,7 +42,7 @@ export const isAuthorized = async (
       // Verified
       return next()
     } else {
-      Logger.info(`decripted: ${JSON.stringify(decripted)}`)
+      Logger.info('Stale session rejected', { userId: decripted.id })
       // A stale session must be treated as logged out so the client can re-authenticate.
       res.cookie('token', '', { expires: new Date() })
       res.status(401).json({ error: 'Invalid or expired token' })

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,17 +1,33 @@
 import type { Request, Response, NextFunction } from 'express'
-import createError from 'http-errors'
-import { TokenExpiredError } from 'jsonwebtoken'
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 
 import { verifyAccessToken } from './lib/JWT'
 import Logger from './lib/Logger'
 import { prisma } from './prisma'
 
+/**
+ * Verifies the cookie JWT before protected API route handlers run.
+ *
+ * Mounted as Express middleware on write operations and external-provider
+ * actions that require a logged-in user.
+ *
+ * @param req - Express request containing the `token` cookie.
+ * @param res - Express response used for authentication failures.
+ * @param next - Express continuation callback for authorized requests.
+ * @returns Nothing; either calls `next()` or completes the response.
+ * @example router.post('/tweet', isAuthorized, handler)
+ */
 export const isAuthorized = async (
   req: Request,
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
   const token = req.cookies.token as JWTtoken
+
+  if (!token) {
+    res.status(401).json({ error: 'No token found' })
+    return
+  }
 
   try {
     const decripted = verifyAccessToken(token) as User & { password: string }
@@ -27,17 +43,21 @@ export const isAuthorized = async (
       return next()
     } else {
       Logger.info(`decripted: ${JSON.stringify(decripted)}`)
-      return next(createError(403, "User doesn't exist."))
+      res.status(403).json({ error: "User doesn't exist." })
+      return
     }
   } catch (error) {
     Logger.error('failed jwt.verify()')
 
     // Expired path
-    if (error instanceof TokenExpiredError) {
-      Logger.warn('Token expired')
+    if (
+      error instanceof TokenExpiredError ||
+      error instanceof JsonWebTokenError
+    ) {
+      Logger.warn('Invalid or expired token')
       // Clear cookie
       res.cookie('token', '', { expires: new Date() })
-      next(createError(401, 'Token expired. Please login again.'))
+      res.status(401).json({ error: 'Invalid or expired token' })
       return
     }
 
@@ -46,6 +66,6 @@ export const isAuthorized = async (
 
     // Clear cookie
     res.cookie('token', '', { expires: new Date() })
-    return next(createError(500, 'Database Connection Error'))
+    res.status(500).json({ error: 'Database Connection Error' })
   }
 }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -43,7 +43,9 @@ export const isAuthorized = async (
       return next()
     } else {
       Logger.info(`decripted: ${JSON.stringify(decripted)}`)
-      res.status(403).json({ error: "User doesn't exist." })
+      // A stale session must be treated as logged out so the client can re-authenticate.
+      res.cookie('token', '', { expires: new Date() })
+      res.status(401).json({ error: 'Invalid or expired token' })
       return
     }
   } catch (error) {
@@ -54,7 +56,7 @@ export const isAuthorized = async (
       error instanceof TokenExpiredError ||
       error instanceof JsonWebTokenError
     ) {
-      Logger.warn('Invalid or expired token')
+      Logger.info('Invalid or expired token')
       // Clear cookie
       res.cookie('token', '', { expires: new Date() })
       res.status(401).json({ error: 'Invalid or expired token' })

--- a/server/lib/requestSchemas.ts
+++ b/server/lib/requestSchemas.ts
@@ -1,0 +1,135 @@
+import { z } from 'zod'
+
+const POST_TITLE_MAX_LENGTH = 400
+const POST_BODY_MAX_LENGTH = 50_000
+const PROFILE_NAME_MAX_LENGTH = 255
+const STOCK_TITLE_MAX_LENGTH = 1_000
+const STOCK_URL_MAX_LENGTH = 2_048
+const TRANSLATE_TEXT_MAX_LENGTH = 5_000
+const TWEET_TEXT_MAX_LENGTH = 280
+const BLUESKY_TEXT_MAX_LENGTH = 300
+const PASSWORD_MAX_LENGTH = 128
+const PASSWORD_MIN_LENGTH = 7
+
+/**
+ * Builds a trimmed string schema for request fields that must contain text.
+ *
+ * Used by API request schemas to keep length and whitespace rules consistent
+ * before route handlers write to Prisma or external APIs.
+ *
+ * @param fieldName - Human-readable field name used in validation messages.
+ * @param maxLength - Maximum accepted string length.
+ * @returns Zod schema that trims and validates a required string field.
+ * @example requiredText('Title', 400).parse(' Hello ')
+ */
+const requiredText = (fieldName: string, maxLength: number) =>
+  z
+    .string()
+    .trim()
+    .min(1, { message: `${fieldName} is required` })
+    .max(maxLength, { message: `${fieldName} is too long` })
+
+const passwordSchema = z
+  .string()
+  .min(PASSWORD_MIN_LENGTH, {
+    message: 'Password must be at least 7 characters long',
+  })
+  .max(PASSWORD_MAX_LENGTH, { message: 'Password is too long' })
+
+export const createPostBodySchema = z
+  .object({
+    author: z.unknown().optional(),
+    body: requiredText('Body', POST_BODY_MAX_LENGTH),
+    title: requiredText('Title', POST_TITLE_MAX_LENGTH),
+  })
+  .strict()
+
+export const updatePostBodySchema = z
+  .object({
+    author: z.unknown().optional(),
+    body: requiredText('Body', POST_BODY_MAX_LENGTH),
+    id: z.coerce.number().int().positive(),
+    title: requiredText('Title', POST_TITLE_MAX_LENGTH),
+  })
+  .strict()
+
+export const signupBodySchema = z
+  .object({
+    name: requiredText('Name', PROFILE_NAME_MAX_LENGTH).min(4, {
+      message: 'Name must be at least 4 characters long',
+    }),
+    password: passwordSchema,
+  })
+  .strict()
+
+export const loginBodySchema = z
+  .object({
+    name: requiredText('Name', PROFILE_NAME_MAX_LENGTH),
+    password: z.string().min(1, { message: 'Password is required' }),
+  })
+  .strict()
+
+export const updateProfileBodySchema = z
+  .object({
+    name: requiredText('Name', PROFILE_NAME_MAX_LENGTH)
+      .min(4, { message: 'Name must be at least 4 characters long' })
+      .optional(),
+    password: passwordSchema.optional(),
+  })
+  .strict()
+  .refine(({ name, password }) => Boolean(name || password), {
+    message: 'At least one field (name or password) must be provided',
+  })
+
+export const hoverColorPreferenceBodySchema = z
+  .object({
+    useLegacyHoverColors: z.boolean(),
+  })
+  .strict()
+
+export const pushStockBodySchema = z
+  .object({
+    pageTitle: requiredText('Page title', STOCK_TITLE_MAX_LENGTH).optional(),
+    title: requiredText('Title', STOCK_TITLE_MAX_LENGTH).optional(),
+    url: z
+      .string()
+      .trim()
+      .url({ message: 'URL is invalid' })
+      .max(STOCK_URL_MAX_LENGTH, { message: 'URL is too long' }),
+  })
+  .strict()
+  .refine(({ pageTitle, title }) => Boolean(pageTitle || title), {
+    message: 'Title is required',
+    path: ['pageTitle'],
+  })
+
+export const createTweetBodySchema = z
+  .object({
+    text: requiredText('Tweet text', TWEET_TEXT_MAX_LENGTH),
+  })
+  .strict()
+
+export const translateBodySchema = z
+  .object({
+    text: requiredText('Text', TRANSLATE_TEXT_MAX_LENGTH),
+  })
+  .strict()
+
+export const blueskyPostBodySchema = z
+  .object({
+    text: requiredText('Text', BLUESKY_TEXT_MAX_LENGTH),
+  })
+  .strict()
+
+export type CreatePostBody = z.output<typeof createPostBodySchema>
+export type UpdatePostBody = z.output<typeof updatePostBodySchema>
+export type SignupBody = z.output<typeof signupBodySchema>
+export type LoginBody = z.output<typeof loginBodySchema>
+export type UpdateProfileBody = z.output<typeof updateProfileBodySchema>
+export type HoverColorPreferenceBody = z.output<
+  typeof hoverColorPreferenceBodySchema
+>
+export type PushStockBody = z.output<typeof pushStockBodySchema>
+export type CreateTweetBody = z.output<typeof createTweetBodySchema>
+export type TranslateBody = z.output<typeof translateBodySchema>
+export type BlueskyPostBody = z.output<typeof blueskyPostBodySchema>

--- a/server/lib/requestSchemas.ts
+++ b/server/lib/requestSchemas.ts
@@ -5,6 +5,7 @@ const POST_BODY_MAX_LENGTH = 50_000
 const PROFILE_NAME_MAX_LENGTH = 255
 const STOCK_TITLE_MAX_LENGTH = 1_000
 const STOCK_URL_MAX_LENGTH = 2_048
+const LANGUAGE_CODE_MAX_LENGTH = 16
 const TRANSLATE_TEXT_MAX_LENGTH = 5_000
 const TWEET_TEXT_MAX_LENGTH = 280
 const BLUESKY_TEXT_MAX_LENGTH = 300
@@ -38,7 +39,6 @@ const passwordSchema = z
 
 export const createPostBodySchema = z
   .object({
-    author: z.unknown().optional(),
     body: requiredText('Body', POST_BODY_MAX_LENGTH),
     title: requiredText('Title', POST_TITLE_MAX_LENGTH),
   })
@@ -46,7 +46,6 @@ export const createPostBodySchema = z
 
 export const updatePostBodySchema = z
   .object({
-    author: z.unknown().optional(),
     body: requiredText('Body', POST_BODY_MAX_LENGTH),
     id: z.coerce.number().int().positive(),
     title: requiredText('Title', POST_TITLE_MAX_LENGTH),
@@ -111,7 +110,9 @@ export const createTweetBodySchema = z
 
 export const translateBodySchema = z
   .object({
+    from: requiredText('From language code', LANGUAGE_CODE_MAX_LENGTH),
     text: requiredText('Text', TRANSLATE_TEXT_MAX_LENGTH),
+    to: requiredText('To language code', LANGUAGE_CODE_MAX_LENGTH),
   })
   .strict()
 

--- a/server/lib/validateRequest.ts
+++ b/server/lib/validateRequest.ts
@@ -55,7 +55,7 @@ export const validateBody =
     // Invalid client input returns a structured 400 without reaching Prisma.
     if (!result.success) {
       const details = formatValidationIssues(result.error.issues)
-      Logger.warn('Request body validation failed', { details })
+      Logger.info('Request body validation failed', { details })
       res.status(400).json({
         error: 'Validation failed',
         code: 'VALIDATION_ERROR',

--- a/server/lib/validateRequest.ts
+++ b/server/lib/validateRequest.ts
@@ -1,0 +1,73 @@
+import type { RequestHandler } from 'express'
+import type { ZodIssue, ZodType } from 'zod'
+
+import Logger from './Logger'
+
+interface ValidationIssue {
+  field: string
+  message: string
+  code: string
+}
+
+/**
+ * Formats a Zod issue path into a stable response field name.
+ *
+ * Called while building validation error responses for request bodies.
+ *
+ * @param path - Zod issue path from the failed schema parse.
+ * @returns Dot-separated field name, or `body` for root-level errors.
+ * @example formatIssuePath(['author', 'name']) // 'author.name'
+ */
+const formatIssuePath = (path: ZodIssue['path']): string => {
+  if (path.length === 0) return 'body'
+  return path.join('.')
+}
+
+/**
+ * Converts Zod issues into the API's structured validation details.
+ *
+ * Called by `validateBody` after `safeParse` fails.
+ *
+ * @param issues - Zod validation issues from the failed parse.
+ * @returns Stable issue objects safe to expose to API clients.
+ * @example formatValidationIssues(error.issues)
+ */
+export const formatValidationIssues = (
+  issues: readonly ZodIssue[],
+): ValidationIssue[] =>
+  issues.map((issue) => ({
+    field: formatIssuePath(issue.path),
+    message: issue.message,
+    code: issue.code,
+  }))
+
+/**
+ * Validates `req.body` with Zod before an Express route handler runs.
+ *
+ * The parsed value replaces `req.body`, so route handlers consume trimmed and
+ * coerced data instead of raw client input.
+ *
+ * @param schema - Zod schema for the route request body.
+ * @returns Express middleware that returns 400 on validation failure.
+ * @example router.post('/create', validateBody(createPostBodySchema), handler)
+ */
+export const validateBody =
+  (schema: ZodType): RequestHandler =>
+  (req, res, next) => {
+    const result = schema.safeParse(req.body)
+
+    // Invalid client input returns a structured 400 without reaching Prisma.
+    if (!result.success) {
+      const details = formatValidationIssues(result.error.issues)
+      Logger.warn('Request body validation failed', JSON.stringify(details))
+      res.status(400).json({
+        error: 'Validation failed',
+        code: 'VALIDATION_ERROR',
+        details,
+      })
+      return
+    }
+
+    req.body = result.data
+    next()
+  }

--- a/server/lib/validateRequest.ts
+++ b/server/lib/validateRequest.ts
@@ -3,11 +3,7 @@ import type { ZodIssue, ZodType } from 'zod'
 
 import Logger from './Logger'
 
-interface ValidationIssue {
-  field: string
-  message: string
-  code: string
-}
+type ValidationIssue = Res.ValidationIssue
 
 /**
  * Formats a Zod issue path into a stable response field name.
@@ -59,7 +55,7 @@ export const validateBody =
     // Invalid client input returns a structured 400 without reaching Prisma.
     if (!result.success) {
       const details = formatValidationIssues(result.error.issues)
-      Logger.warn('Request body validation failed', JSON.stringify(details))
+      Logger.warn('Request body validation failed', { details })
       res.status(400).json({
         error: 'Validation failed',
         code: 'VALIDATION_ERROR',

--- a/server/routes/bluesky.ts
+++ b/server/routes/bluesky.ts
@@ -2,6 +2,12 @@ import { BskyAgent, RichText } from '@atproto/api'
 import express from 'express'
 import type { Router } from 'express'
 
+import {
+  blueskyPostBodySchema,
+  type BlueskyPostBody,
+} from '../lib/requestSchemas'
+import { validateBody } from '../lib/validateRequest'
+
 const router: Router = express.Router()
 
 // Initialize BlueSky agent
@@ -41,61 +47,53 @@ const ensureAuthenticated = async (): Promise<void> => {
 }
 
 // POST /api/bluesky/post
-router.post('/bluesky/post', async (req, res) => {
-  try {
-    const { text } = req.body
+router.post(
+  '/bluesky/post',
+  validateBody(blueskyPostBodySchema),
+  async (req, res) => {
+    try {
+      const { text } = req.body as BlueskyPostBody
 
-    if (!text || typeof text !== 'string') {
-      return res
-        .status(400)
-        .json({ error: 'Text is required and must be a string' })
+      // Ensure we're authenticated
+      await ensureAuthenticated()
+
+      // Create rich text with automatic facet detection
+      const richText = new RichText({ text })
+      await richText.detectFacets(agent)
+
+      // Create the post
+      const postResult = await agent.post({
+        text: richText.text,
+        facets: richText.facets,
+        createdAt: new Date().toISOString(),
+      })
+
+      res.json({
+        success: true,
+        postUri: postResult.uri,
+        postCid: postResult.cid,
+        message: 'Successfully posted to BlueSky',
+      })
+    } catch (error) {
+      console.error('BlueSky post error:', error)
+
+      // Reset authentication state on auth errors
+      if (
+        error instanceof Error &&
+        (error.message.includes('authentication') ||
+          error.message.includes('unauthorized') ||
+          error.message.includes('invalid'))
+      ) {
+        authState.isAuthenticated = false
+      }
+
+      res.status(500).json({
+        error: 'Failed to post to BlueSky',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      })
     }
-
-    if (text.length > 300) {
-      return res
-        .status(400)
-        .json({ error: 'Text must be 300 characters or less' })
-    }
-
-    // Ensure we're authenticated
-    await ensureAuthenticated()
-
-    // Create rich text with automatic facet detection
-    const richText = new RichText({ text })
-    await richText.detectFacets(agent)
-
-    // Create the post
-    const postResult = await agent.post({
-      text: richText.text,
-      facets: richText.facets,
-      createdAt: new Date().toISOString(),
-    })
-
-    res.json({
-      success: true,
-      postUri: postResult.uri,
-      postCid: postResult.cid,
-      message: 'Successfully posted to BlueSky',
-    })
-  } catch (error) {
-    console.error('BlueSky post error:', error)
-
-    // Reset authentication state on auth errors
-    if (
-      error instanceof Error &&
-      (error.message.includes('authentication') ||
-        error.message.includes('unauthorized') ||
-        error.message.includes('invalid'))
-    ) {
-      authState.isAuthenticated = false
-    }
-
-    res.status(500).json({
-      error: 'Failed to post to BlueSky',
-      details: error instanceof Error ? error.message : 'Unknown error',
-    })
-  }
-})
+  },
+)
 
 // GET /api/bluesky/status - Check authentication status
 router.get('/bluesky/status', async (req, res) => {

--- a/server/routes/bluesky.ts
+++ b/server/routes/bluesky.ts
@@ -2,6 +2,7 @@ import { BskyAgent, RichText } from '@atproto/api'
 import express from 'express'
 import type { Router } from 'express'
 
+import { isAuthorized } from '../auth'
 import {
   blueskyPostBodySchema,
   type BlueskyPostBody,
@@ -49,6 +50,7 @@ const ensureAuthenticated = async (): Promise<void> => {
 // POST /api/bluesky/post
 router.post(
   '/bluesky/post',
+  isAuthorized,
   validateBody(blueskyPostBodySchema),
   async (req, res) => {
     try {
@@ -70,8 +72,8 @@ router.post(
 
       res.json({
         success: true,
-        postUri: postResult.uri,
-        postCid: postResult.cid,
+        uri: postResult.uri,
+        cid: postResult.cid,
         message: 'Successfully posted to BlueSky',
       })
     } catch (error) {

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -3,6 +3,13 @@ import express from 'express'
 
 import { isAuthorized } from '../auth'
 import Logger from '../lib/Logger'
+import {
+  createPostBodySchema,
+  type CreatePostBody,
+  type UpdatePostBody,
+  updatePostBodySchema,
+} from '../lib/requestSchemas'
+import { validateBody } from '../lib/validateRequest'
 import { prisma } from '../prisma'
 
 const router: Router = express.Router()
@@ -98,38 +105,44 @@ router.get(
   },
 )
 
-router.post('/create', isAuthorized, async (req: Request, res: Response) => {
-  const { title, body } = req.body
-  try {
-    const post = await prisma.post.create({
-      data: {
-        title: title,
-        body: body,
-      },
-    })
-    res.status(201).json(post)
-  } catch (error: unknown) {
-    if (error instanceof Error) {
-      Logger.error(error)
-      res.status(500).json({ error: error.message })
-    } else {
-      Logger.error(error)
-      res.status(500).json({
-        error: `something wrong: ${JSON.stringify(error)}`,
+router.post(
+  '/create',
+  isAuthorized,
+  validateBody(createPostBodySchema),
+  async (req: Request, res: Response) => {
+    const { title, body } = req.body as CreatePostBody
+    try {
+      const post = await prisma.post.create({
+        data: {
+          title: title,
+          body: body,
+        },
       })
+      res.status(201).json(post)
+    } catch (error: unknown) {
+      if (error instanceof Error) {
+        Logger.error(error)
+        res.status(500).json({ error: error.message })
+      } else {
+        Logger.error(error)
+        res.status(500).json({
+          error: `something wrong: ${JSON.stringify(error)}`,
+        })
+      }
     }
-  }
-})
+  },
+)
 
 router.post(
   '/update',
   isAuthorized,
+  validateBody(updatePostBodySchema),
   async (req: Request, res: Response, next: NextFunction) => {
-    const body = req.body
+    const body = req.body as UpdatePostBody
     try {
       await prisma.post.update({
         data: { title: body.title, body: body.body },
-        where: { id: parseInt(body.id, 10) },
+        where: { id: body.id },
       })
 
       res.status(200).json({ message: 'Successfully Updated!' })

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -3,6 +3,8 @@ import express from 'express'
 
 import { isAuthorized } from '../auth'
 import Logger from '../lib/Logger'
+import { pushStockBodySchema, type PushStockBody } from '../lib/requestSchemas'
+import { validateBody } from '../lib/validateRequest'
 import { prisma } from '../prisma'
 
 const router: Router = express.Router()
@@ -73,8 +75,9 @@ const stockUrlExists = async (url: string): Promise<boolean> => {
 
 router.post(
   '/push_stock',
+  validateBody(pushStockBodySchema),
   async (req: Request, res: Response, next: NextFunction) => {
-    const body = req.body
+    const body = req.body as PushStockBody
     const pageTitle = normalizeStockTitle(body.pageTitle ?? body.title)
     const normalizedUrl = normalizeStockUrl(body.url)
 

--- a/server/routes/translate.ts
+++ b/server/routes/translate.ts
@@ -3,6 +3,9 @@ import type { RequestHandler, Router } from 'express'
 import rateLimit from 'express-rate-limit'
 import OpenAI from 'openai'
 
+import { translateBodySchema, type TranslateBody } from '../lib/requestSchemas'
+import { validateBody } from '../lib/validateRequest'
+
 const router: Router = express.Router()
 
 const ONE_MINUTE_MS = 60 * 1000
@@ -46,58 +49,57 @@ const isJapanese = (text: string): boolean => {
 }
 
 // POST /api/translate
-router.post('/translate', translateLimiter, async (req, res) => {
-  try {
-    const { text } = req.body
+router.post(
+  '/translate',
+  translateLimiter,
+  validateBody(translateBodySchema),
+  async (req, res) => {
+    try {
+      const { text } = req.body as TranslateBody
 
-    if (!text || typeof text !== 'string') {
-      return res
-        .status(400)
-        .json({ error: 'Text is required and must be a string' })
+      // If text is not Japanese, return as is
+      if (!isJapanese(text)) {
+        return res.json({ translatedText: text, isTranslated: false })
+      }
+
+      // Translate Japanese text to English
+      const openai = getOpenAIClient()
+      const completion = await openai.chat.completions.create({
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'system',
+            content:
+              'You are a professional translator. Translate the following Japanese text to English. Keep the tone and meaning intact. Return only the translation without any additional text or explanations.',
+          },
+          {
+            role: 'user',
+            content: text,
+          },
+        ],
+        max_tokens: 500,
+        temperature: 0.3,
+      })
+
+      const translatedText = completion.choices[0]?.message?.content?.trim()
+
+      if (!translatedText) {
+        throw new Error('Translation failed - no response from OpenAI')
+      }
+
+      res.json({
+        translatedText,
+        isTranslated: true,
+        originalText: text,
+      })
+    } catch (error) {
+      console.error('Translation error:', error)
+      res.status(500).json({
+        error: 'Translation failed',
+        details: error instanceof Error ? error.message : 'Unknown error',
+      })
     }
-
-    // If text is not Japanese, return as is
-    if (!isJapanese(text)) {
-      return res.json({ translatedText: text, isTranslated: false })
-    }
-
-    // Translate Japanese text to English
-    const openai = getOpenAIClient()
-    const completion = await openai.chat.completions.create({
-      model: 'gpt-4o',
-      messages: [
-        {
-          role: 'system',
-          content:
-            'You are a professional translator. Translate the following Japanese text to English. Keep the tone and meaning intact. Return only the translation without any additional text or explanations.',
-        },
-        {
-          role: 'user',
-          content: text,
-        },
-      ],
-      max_tokens: 500,
-      temperature: 0.3,
-    })
-
-    const translatedText = completion.choices[0]?.message?.content?.trim()
-
-    if (!translatedText) {
-      throw new Error('Translation failed - no response from OpenAI')
-    }
-
-    res.json({
-      translatedText,
-      isTranslated: true,
-      originalText: text,
-    })
-  } catch (error) {
-    console.error('Translation error:', error)
-    res.status(500).json({
-      error: 'Translation failed',
-      details: error instanceof Error ? error.message : 'Unknown error',
-    })
-  }
-})
+  },
+)
 
 export default router

--- a/server/routes/translate.ts
+++ b/server/routes/translate.ts
@@ -3,6 +3,8 @@ import type { RequestHandler, Router } from 'express'
 import rateLimit from 'express-rate-limit'
 import OpenAI from 'openai'
 
+import { isAuthorized } from '../auth'
+import Logger from '../lib/Logger'
 import { translateBodySchema, type TranslateBody } from '../lib/requestSchemas'
 import { validateBody } from '../lib/validateRequest'
 
@@ -52,6 +54,7 @@ const isJapanese = (text: string): boolean => {
 router.post(
   '/translate',
   translateLimiter,
+  isAuthorized,
   validateBody(translateBodySchema),
   async (req, res) => {
     try {
@@ -93,11 +96,23 @@ router.post(
         originalText: text,
       })
     } catch (error) {
-      console.error('Translation error:', error)
-      res.status(500).json({
+      Logger.error('Translation error', { error })
+      const responseBody: Res.Error = {
         error: 'Translation failed',
-        details: error instanceof Error ? error.message : 'Unknown error',
-      })
+      }
+
+      // Internal provider details are only exposed during local development.
+      if (process.env.NODE_ENV === 'development') {
+        responseBody.details = [
+          {
+            field: 'text',
+            message: error instanceof Error ? error.message : 'Unknown error',
+            code: 'TRANSLATION_ERROR',
+          },
+        ]
+      }
+
+      res.status(500).json(responseBody)
     }
   },
 )

--- a/server/routes/tweet.ts
+++ b/server/routes/tweet.ts
@@ -1,6 +1,11 @@
 import type { Request, Response, Router, NextFunction } from 'express'
 import express from 'express'
 
+import {
+  createTweetBodySchema,
+  type CreateTweetBody,
+} from '../lib/requestSchemas'
+import { validateBody } from '../lib/validateRequest'
 import { prisma } from '../prisma'
 
 const tweet: Router = express.Router()
@@ -62,16 +67,20 @@ tweet.get(
   },
 )
 
-tweet.post('/', async (req: Request, res: Response, next: NextFunction) => {
-  try {
-    const { text } = req.body
-    const tweet = await prisma.tweet.create({ data: { text } })
+tweet.post(
+  '/',
+  validateBody(createTweetBodySchema),
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { text } = req.body as CreateTweetBody
+      const tweet = await prisma.tweet.create({ data: { text } })
 
-    res.status(201).json(tweet)
-  } catch (error) {
-    next(error)
-  }
-})
+      res.status(201).json(tweet)
+    } catch (error) {
+      next(error)
+    }
+  },
+)
 
 tweet.delete(
   '/:id',

--- a/server/routes/tweet.ts
+++ b/server/routes/tweet.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, Router, NextFunction } from 'express'
 import express from 'express'
 
+import { isAuthorized } from '../auth'
 import {
   createTweetBodySchema,
   type CreateTweetBody,
@@ -69,6 +70,7 @@ tweet.get(
 
 tweet.post(
   '/',
+  isAuthorized,
   validateBody(createTweetBodySchema),
   async (req: Request, res: Response, next: NextFunction) => {
     try {

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -2,6 +2,7 @@ import bcrypt from 'bcrypt'
 import type { Request, Response, Router, RequestHandler } from 'express'
 import express from 'express'
 import rateLimit from 'express-rate-limit'
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 
 import {
   generateAccessToken,
@@ -92,6 +93,35 @@ const sendAuthenticationFailure = (
     error: AUTHENTICATION_FAILED_MESSAGE,
     code: AUTHENTICATION_FAILED_CODE,
   })
+}
+
+/**
+ * Detects token verification failures thrown by `verifyAccessToken`.
+ *
+ * Called by PATCH handlers so invalid cookies return 401 instead of being
+ * misclassified as server failures.
+ *
+ * @param error - Unknown error thrown while verifying a cookie token.
+ * @returns Whether the error is an authentication failure.
+ * @example isTokenVerificationError(new JsonWebTokenError('jwt malformed'))
+ */
+const isTokenVerificationError = (error: unknown): boolean => {
+  return (
+    error instanceof TokenExpiredError || error instanceof JsonWebTokenError
+  )
+}
+
+/**
+ * Sends the shared response for invalid or expired cookie tokens.
+ *
+ * Called by account-setting PATCH endpoints after token verification fails.
+ *
+ * @param res - Express response used to return the 401 payload.
+ * @returns Nothing; the response is completed with status 401.
+ * @example sendInvalidTokenResponse(res)
+ */
+const sendInvalidTokenResponse = (res: Response<Res.Error>): void => {
+  res.status(401).json({ error: 'Invalid or expired token' })
 }
 
 router.get(
@@ -296,6 +326,11 @@ router.patch(
       res.status(200).json({ useLegacyHoverColors: user.useLegacyHoverColors })
     } catch (error) {
       Logger.error(error)
+      if (isTokenVerificationError(error)) {
+        sendInvalidTokenResponse(res)
+        return
+      }
+
       res.status(500).json({ error: 'Failed to update hover color preference' })
     }
   },
@@ -344,6 +379,11 @@ router.patch(
       res.status(200).json(user)
     } catch (error) {
       Logger.error(error)
+      if (isTokenVerificationError(error)) {
+        sendInvalidTokenResponse(res)
+        return
+      }
+
       res.status(500).json({ error: 'Failed to update profile' })
     }
   },

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -121,6 +121,8 @@ const isTokenVerificationError = (error: unknown): boolean => {
  * @example sendInvalidTokenResponse(res)
  */
 const sendInvalidTokenResponse = (res: Response<Res.Error>): void => {
+  // Expire the rejected session cookie so clients stop replaying it.
+  res.cookie('token', '', { expires: new Date() })
   res.status(401).json({ error: 'Invalid or expired token' })
 }
 

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -9,6 +9,16 @@ import {
   verifyAccessToken,
 } from '../lib/JWT'
 import Logger from '../lib/Logger'
+import {
+  hoverColorPreferenceBodySchema,
+  type HoverColorPreferenceBody,
+  loginBodySchema,
+  signupBodySchema,
+  type SignupBody,
+  updateProfileBodySchema,
+  type UpdateProfileBody,
+} from '../lib/requestSchemas'
+import { formatValidationIssues, validateBody } from '../lib/validateRequest'
 import { prisma } from '../prisma'
 
 const router: Router = express.Router()
@@ -20,8 +30,6 @@ const AUTHENTICATION_SERVICE_ERROR_MESSAGE =
   'Authentication service temporarily unavailable'
 const DUMMY_PASSWORD_HASH =
   '$2b$10$PDIcmRmxvgVeIaa/c9AWiu4wRQD7EwBjczFqVDjgMtsj4.To0W5aC'
-const INVALID_LOGIN_REQUEST_CODE = 'VALIDATION_ERROR'
-const INVALID_LOGIN_REQUEST_MESSAGE = 'Invalid request body'
 const LOGIN_WINDOW_MS = 15 * 60 * 1000
 const LOGIN_MAX_ATTEMPTS = 5
 const isProd = process.env.NODE_ENV === 'production'
@@ -36,11 +44,6 @@ const loginLimiter: RequestHandler = isProd
       },
     })
   : (_req, _res, next) => next()
-
-interface SignupRequest {
-  name: string
-  password: string
-}
 
 /**
  * Converts a submitted login name into the database lookup value.
@@ -75,8 +78,8 @@ const normalizeLoginPassword = (password: unknown): string => {
 /**
  * Sends the public login failure response shared by every credential failure.
  *
- * Called by `/api/login` whenever the username is unknown, the password is
- * wrong, or the submitted body is malformed.
+ * Called by `/api/login` whenever the username is unknown or the password is
+ * wrong.
  *
  * @param res - Express response used to return the failed login payload.
  * @returns Nothing; the response is completed with status 401.
@@ -91,25 +94,6 @@ const sendAuthenticationFailure = (
   })
 }
 
-/**
- * Sends the public validation response for malformed login requests.
- *
- * Called by `/api/login` after the dummy bcrypt comparison has run, so invalid
- * bodies still avoid a cheap early exit while using the correct HTTP status.
- *
- * @param res - Express response used to return the validation error payload.
- * @returns Nothing; the response is completed with status 400.
- * @example sendInvalidLoginRequest(res)
- */
-const sendInvalidLoginRequest = (
-  res: Response<Res.Login | Res.AuthError | Res.Error>,
-): void => {
-  res.status(400).json({
-    error: INVALID_LOGIN_REQUEST_MESSAGE,
-    code: INVALID_LOGIN_REQUEST_CODE,
-  })
-}
-
 router.get(
   '/user_count',
   async (_req: Request, res: Response<Res.GetUserCount>) => {
@@ -119,15 +103,7 @@ router.get(
 )
 
 const signupHandler: RequestHandler = async (req, res) => {
-  const body = req.body as SignupRequest
-  if (!(body?.name && body?.password)) {
-    Logger.warn('Empty Post Content. Might be data not formatted properly.')
-    res.status(400).json({
-      error: 'Empty Post Content. Might be data not formatted properly.',
-    })
-    return
-  }
-
+  const body = req.body as SignupBody
   const salt = await bcrypt.genSalt(10)
   const hash = await bcrypt.hash(body.password, salt)
 
@@ -161,7 +137,7 @@ const signupHandler: RequestHandler = async (req, res) => {
   }
 }
 
-router.post('/signup', signupHandler)
+router.post('/signup', validateBody(signupBodySchema), signupHandler)
 
 router.post(
   '/login',
@@ -170,18 +146,27 @@ router.post(
     { body }: Request,
     res: Response<Res.Login | Res.AuthError | Res.Error>,
   ) => {
-    const name = normalizeLoginName(body?.name)
-    const password = normalizeLoginPassword(body?.password)
+    const parsedBody = loginBodySchema.safeParse(body)
+    const name = parsedBody.success
+      ? parsedBody.data.name
+      : normalizeLoginName(body?.name)
+    const password = parsedBody.success
+      ? parsedBody.data.password
+      : normalizeLoginPassword(body?.password)
 
     try {
       // Malformed bodies still run bcrypt but return the validation status.
-      if (!(name && password)) {
+      if (!parsedBody.success) {
         await bcrypt.compare(
           password || 'missing-password',
           DUMMY_PASSWORD_HASH,
         )
         Logger.warn('Invalid login payload')
-        sendInvalidLoginRequest(res)
+        res.status(400).json({
+          error: 'Validation failed',
+          code: 'VALIDATION_ERROR',
+          details: formatValidationIssues(parsedBody.error.issues),
+        })
         return
       }
 
@@ -285,88 +270,83 @@ router.get('/hover-color-preference', async (req: Request, res: Response) => {
   }
 })
 
-router.patch('/hover-color-preference', async (req: Request, res: Response) => {
-  const token = req.cookies.token as JWTtoken
+router.patch(
+  '/hover-color-preference',
+  validateBody(hoverColorPreferenceBodySchema),
+  async (req: Request, res: Response) => {
+    const token = req.cookies.token as JWTtoken
 
-  if (!token) {
-    res.status(401).json({ error: 'No token found' })
-    return
-  }
-
-  try {
-    const decoded = verifyAccessToken(token)
-    const { useLegacyHoverColors } = req.body
-
-    if (typeof useLegacyHoverColors !== 'boolean') {
-      res.status(400).json({ error: 'useLegacyHoverColors must be a boolean' })
+    if (!token) {
+      res.status(401).json({ error: 'No token found' })
       return
     }
 
-    const user = await prisma.user.update({
-      where: { id: decoded.id },
-      data: { useLegacyHoverColors },
-      select: {
-        useLegacyHoverColors: true,
-      },
-    })
+    try {
+      const decoded = verifyAccessToken(token)
+      const { useLegacyHoverColors } = req.body as HoverColorPreferenceBody
 
-    res.status(200).json({ useLegacyHoverColors: user.useLegacyHoverColors })
-  } catch (error) {
-    Logger.error(error)
-    res.status(500).json({ error: 'Failed to update hover color preference' })
-  }
-})
-
-router.patch('/profile', async (req: Request, res: Response) => {
-  const token = req.cookies.token as JWTtoken
-
-  if (!token) {
-    res.status(401).json({ error: 'No token found' })
-    return
-  }
-
-  try {
-    const decoded = verifyAccessToken(token)
-    const { name, password } = req.body
-
-    // Validate that at least one field is being updated
-    if (!name && !password) {
-      res.status(400).json({
-        error: 'At least one field (name or password) must be provided',
+      const user = await prisma.user.update({
+        where: { id: decoded.id },
+        data: { useLegacyHoverColors },
+        select: {
+          useLegacyHoverColors: true,
+        },
       })
+
+      res.status(200).json({ useLegacyHoverColors: user.useLegacyHoverColors })
+    } catch (error) {
+      Logger.error(error)
+      res.status(500).json({ error: 'Failed to update hover color preference' })
+    }
+  },
+)
+
+router.patch(
+  '/profile',
+  validateBody(updateProfileBodySchema),
+  async (req: Request, res: Response) => {
+    const token = req.cookies.token as JWTtoken
+
+    if (!token) {
+      res.status(401).json({ error: 'No token found' })
       return
     }
 
-    // Prepare update data
-    const updateData: { name?: string; password?: string } = {}
+    try {
+      const decoded = verifyAccessToken(token)
+      const { name, password } = req.body as UpdateProfileBody
 
-    if (name) {
-      updateData.name = name
+      // Prepare update data
+      const updateData: { name?: string; password?: string } = {}
+
+      if (name) {
+        updateData.name = name
+      }
+
+      if (password) {
+        // Hash the new password
+        const salt = await bcrypt.genSalt(10)
+        updateData.password = await bcrypt.hash(password, salt)
+      }
+
+      // Update user in database
+      const user = await prisma.user.update({
+        where: { id: decoded.id },
+        data: updateData,
+        select: {
+          id: true,
+          name: true,
+          createdAt: true,
+          updatedAt: true,
+        },
+      })
+
+      res.status(200).json(user)
+    } catch (error) {
+      Logger.error(error)
+      res.status(500).json({ error: 'Failed to update profile' })
     }
-
-    if (password) {
-      // Hash the new password
-      const salt = await bcrypt.genSalt(10)
-      updateData.password = await bcrypt.hash(password, salt)
-    }
-
-    // Update user in database
-    const user = await prisma.user.update({
-      where: { id: decoded.id },
-      data: updateData,
-      select: {
-        id: true,
-        name: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-    })
-
-    res.status(200).json(user)
-  } catch (error) {
-    Logger.error(error)
-    res.status(500).json({ error: 'Failed to update profile' })
-  }
-})
+  },
+)
 
 export default router

--- a/src/components/TweetCard/index.tsx
+++ b/src/components/TweetCard/index.tsx
@@ -40,7 +40,11 @@ export const TweetCard: React.FC<Props & ComponentProps<'div'>> = ({
 
   const handleTranslate = async () => {
     try {
-      const result = await translateText(tweet.text).unwrap()
+      const result = await translateText({
+        text: tweet.text,
+        from: 'ja',
+        to: 'en',
+      }).unwrap()
 
       if (result.isTranslated) {
         // Create a new tweet with the translated text

--- a/src/pages/Dashboard/Create/handlers.ts
+++ b/src/pages/Dashboard/Create/handlers.ts
@@ -1,7 +1,6 @@
 import type { ChangeEvent } from 'react'
 import type { NavigateFunction } from 'react-router'
 
-import type { AdminState } from '../../../redux/adminSlice'
 import type { API } from '../../../redux/API'
 import type { DraftState } from '../../../redux/draftSlice'
 import { updateBody, updateTitle, clearDraft } from '../../../redux/draftSlice'
@@ -23,12 +22,10 @@ export async function onSubmit(
   createPost: ReturnType<typeof API.endpoints.createPost.useMutation>[0],
   title: DraftState['title'],
   body: DraftState['body'],
-  author: AdminState['author'],
   navigate: NavigateFunction,
 ) {
   const post = await createPost({
     title,
-    author,
     body,
   })
   // @TODO Rewrite mutation error handling flow

--- a/src/pages/Dashboard/Create/index.tsx
+++ b/src/pages/Dashboard/Create/index.tsx
@@ -9,7 +9,6 @@ import Layout from '@/src/components/Layout'
 import Textarea from '@/src/components/Textarea/Textarea'
 
 import { createPostFormValidator } from '../../../../validator'
-import { selectUser } from '../../../redux/adminSlice'
 import { API } from '../../../redux/API'
 import { selectBody, selectTitle } from '../../../redux/draftSlice'
 import type { FormInput } from '../../../redux/draftSlice'
@@ -23,7 +22,6 @@ const Create: React.FC = memo(() => {
   const [createPost, { isLoading }] = API.endpoints.createPost.useMutation()
   const title = useAppSelector(selectTitle)
   const body = useAppSelector(selectBody)
-  const user = useAppSelector(selectUser)
   const {
     formState: { errors },
     handleSubmit,
@@ -37,7 +35,7 @@ const Create: React.FC = memo(() => {
       <section className="w-[70%]">
         <form
           onSubmit={handleSubmit(async () =>
-            onSubmit(createPost, title, body, user, navigate),
+            onSubmit(createPost, title, body, navigate),
           )}
         >
           <Input

--- a/src/pages/Dashboard/Edit/handlers.ts
+++ b/src/pages/Dashboard/Edit/handlers.ts
@@ -1,7 +1,6 @@
 import type { UseFormGetValues } from 'react-hook-form'
 import type { NavigateFunction } from 'react-router'
 
-import type { AdminState } from '../../../redux/adminSlice'
 import type { FormInput } from '../../../redux/draftSlice'
 import isSuccess from '../../../redux/helper/isSuccess'
 import { enqueSnackbar } from '../../../redux/snackbarSlice'
@@ -9,7 +8,6 @@ import type { AppDispatch } from '../../../redux/store'
 
 export async function onSubmit(
   updatePost: AnyFunction, // @TODO refactor to certain types
-  author: AdminState['author'], // @TODO remove after remove author from updatePost mutation
   getValues: UseFormGetValues<FormInput>,
   navigate: NavigateFunction,
   id: Post['id'],
@@ -18,7 +16,6 @@ export async function onSubmit(
   const response = await updatePost({
     id: id,
     title: getValues('title'),
-    author: author,
     body: getValues('body'),
   })
 

--- a/src/pages/Dashboard/Edit/index.tsx
+++ b/src/pages/Dashboard/Edit/index.tsx
@@ -12,10 +12,8 @@ import Textarea from '@/src/components/Textarea/Textarea'
 
 import { assertIsDefined } from '../../../../lib/assertIsDefined'
 import { editPostFormValidator } from '../../../../validator'
-import { selectUser } from '../../../redux/adminSlice'
 import { API } from '../../../redux/API'
 import type { FormInput } from '../../../redux/draftSlice'
-import { useAppSelector } from '../../../redux/hooks'
 import { dispatch } from '../../../redux/store'
 
 import { onSubmit } from './handlers'
@@ -28,7 +26,6 @@ const Edit: React.FC = memo(() => {
   const [updatePost, { isLoading: isUpdating }] =
     API.endpoints.updatePost.useMutation()
   const navigate = useNavigate()
-  const user = useAppSelector(selectUser)
   const {
     formState: { errors },
     getValues,
@@ -50,7 +47,7 @@ const Edit: React.FC = memo(() => {
     <form
       data-testid="edit-form"
       onSubmit={handleSubmit(async () =>
-        onSubmit(updatePost, user, getValues, navigate, id, dispatch),
+        onSubmit(updatePost, getValues, navigate, id, dispatch),
       )}
     >
       <Input

--- a/src/redux/API.ts
+++ b/src/redux/API.ts
@@ -214,19 +214,19 @@ export const API = createApi({
         isTranslated: boolean
         originalText?: string
       },
-      string
+      { text: string; from: string; to: string }
     >({
-      query: (text: string) => ({
+      query: (payload) => ({
         method: 'POST',
         url: 'translate',
-        body: { text },
+        body: payload,
       }),
     }),
     postToBlueSky: builder.mutation<
       {
         success: boolean
-        postUri: string
-        postCid: string
+        uri: string
+        cid: string
         message: string
       },
       string


### PR DESCRIPTION
## Summary
- add shared Zod request body schemas and Express validation middleware
- validate post, user, stock, tweet, translate, and BlueSky write bodies before Prisma/external calls
- return structured 400 `VALIDATION_ERROR` responses and cover invalid payloads with Playwright API tests

Closes #3732
Closes #3589

## Validation
- pnpm typecheck
- pnpm lint
- pnpm playwright e2e/admin/api-validation.spec.ts e2e/admin/login-logout.spec.ts e2e/admin/profile-update.spec.ts e2e/admin/tweet-crud.spec.ts e2e/admin/tweet-pagination.spec.ts
- pnpm validate
- pnpm server:build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Standardized request validation across API endpoints with consistent 400 responses and structured field-level error details.
  * Auth middleware now returns clearer token/authorization errors and clears invalid tokens.

* **Behavior Changes**
  * Translation requests include explicit source/target languages; translation error details shown only in development.
  * BlueSky responses now use renamed URI/CID fields.
  * Post create/edit flows no longer send an author field.

* **Tests**
  * Added end-to-end tests for API request validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3763?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->