### PR TITLE
Fix API authorization and session rotation

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -6,6 +6,7 @@ VITE_GA_MEASUREMENT_ID=""
 
 # Server
 ACCESS_TOKEN_SECRET=your_jwt_secret_here
+REFRESH_TOKEN_SECRET=your_refresh_jwt_secret_here
 # Dev (compose.dev publishes 3306): TCP
 DATABASE_URL="mysql://root:your_mysql_root_password@127.0.0.1:3306/digital"
 # Production (compose.prod, PM2 on host): no TCP; use socketPath (URL-encode path if needed)

--- a/@types/app.d.ts
+++ b/@types/app.d.ts
@@ -11,6 +11,7 @@ declare interface User {
 
 declare interface Post {
   id: number
+  authorId: number
   title: string
   body: string
   createdAt: string
@@ -25,13 +26,33 @@ declare interface Stock {
   pageTitle: string
   updatedAt: string
   url: string
+  userId: number
 }
 
 declare type StockList = Stock[]
+
+declare interface Tweet {
+  id: number
+  text: string
+  createdAt: string
+  updatedAt: string
+  userId: number
+}
 
 /**
  * Authentication
  */
 declare type JWTtoken = string
 
-declare type JWTpayload = User // Password is already omitted from User type
+declare interface AuthenticatedUser extends User {
+  password: string
+  useLegacyHoverColors: boolean
+}
+
+declare type JWTpayload = AuthenticatedUser
+
+declare namespace Express {
+  export interface Request {
+    authenticatedUser?: AuthenticatedUser
+  }
+}

--- a/@types/app.d.ts
+++ b/@types/app.d.ts
@@ -46,6 +46,7 @@ declare type JWTtoken = string
 
 declare interface AuthenticatedUser extends User {
   password: string
+  sessionVersion: number
   useLegacyHoverColors: boolean
 }
 

--- a/@types/prisma.d.ts
+++ b/@types/prisma.d.ts
@@ -16,7 +16,7 @@ declare module '@prisma/client' {
     updatedAt: string
   }
 
-  export interface tweet {
+  export interface Tweet {
     createdAt: string
     updatedAt: string
   }

--- a/@types/response.d.ts
+++ b/@types/response.d.ts
@@ -46,17 +46,17 @@ declare namespace Res {
    * Deletre /api/:id
    */
   declare interface DeletePost {
-    message: 'Delete Successful!'
+    success: true
   }
 
   // POST: /api/logout
   declare interface Logout {
-    message: 'Logout Successful'
+    success: true
   }
 
   // DELETE /api/stock/:id
   declare interface DeleteStock {
-    message: 'Delete Successful!'
+    success: true
   }
   /**
    * API Reqest/Response body types

--- a/e2e/admin/api-validation.spec.ts
+++ b/e2e/admin/api-validation.spec.ts
@@ -130,8 +130,8 @@ test.describe('API request validation', () => {
     })
   })
 
-  test('rejects invalid public integration bodies with structured details', async ({
-    page,
+  test('rejects invalid integration bodies with structured details', async ({
+    authenticated: page,
   }) => {
     // Arrange
     const invalidSignupPayload = {

--- a/e2e/admin/authentication.spec.ts
+++ b/e2e/admin/authentication.spec.ts
@@ -8,8 +8,6 @@ import { test } from '../helper'
 
 const exec = util.promisify(execCb)
 const API_BASE_URL = 'http://localhost:4000/api'
-const JOHN_DOE_PASSWORD_HASH =
-  '$2b$10$PDIcmRmxvgVeIaa/c9AWiu4wRQD7EwBjczFqVDjgMtsj4.To0W5aC'
 
 test.beforeAll(async () => {
   await exec('PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset')
@@ -102,16 +100,20 @@ test.describe('JWT Expiration', () => {
     expect(originalTokenCookie).toBeTruthy()
     expect(originalRefreshCookie).toBeTruthy()
 
+    const accessTokenSecret = process.env.ACCESS_TOKEN_SECRET
+    if (!accessTokenSecret) {
+      throw new Error(
+        'ACCESS_TOKEN_SECRET must be set for admin refresh-rotation E2E',
+      )
+    }
+
     const expiredAccessToken = jwt.sign(
       {
-        id: 1,
-        name: 'John Doe',
-        password: JOHN_DOE_PASSWORD_HASH,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        useLegacyHoverColors: false,
+        kind: 'access',
+        sessionVersion: 0,
+        sub: '1',
       },
-      process.env.ACCESS_TOKEN_SECRET!,
+      accessTokenSecret,
       { expiresIn: '-1s' },
     )
 

--- a/e2e/admin/authentication.spec.ts
+++ b/e2e/admin/authentication.spec.ts
@@ -2,20 +2,25 @@ import { exec as execCb } from 'node:child_process'
 import util from 'node:util'
 
 import { expect } from '@playwright/test'
+import jwt from 'jsonwebtoken'
 
 import { test } from '../helper'
 
 const exec = util.promisify(execCb)
+const API_BASE_URL = 'http://localhost:4000/api'
+const JOHN_DOE_PASSWORD_HASH =
+  '$2b$10$PDIcmRmxvgVeIaa/c9AWiu4wRQD7EwBjczFqVDjgMtsj4.To0W5aC'
 
 test.beforeAll(async () => {
   await exec('PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset')
 })
 
 test.describe('JWT Expiration', () => {
-  test('cookie expiration should match JWT token expiration', async ({
+  test('login sets a one-hour access cookie and a seven-day refresh cookie', async ({
     page,
     context,
   }) => {
+    // Arrange
     // Navigate to login page
     await page.goto('http://localhost:3010')
     await page.keyboard.press('x')
@@ -31,9 +36,11 @@ test.describe('JWT Expiration', () => {
     // Wait for navigation or for login error
     await page.waitForLoadState('networkidle')
 
-    // Get cookies from the context after login
+    // Act
+    // Get cookies from the context after login.
     const cookies = await context.cookies()
     const tokenCookie = cookies.find((c) => c.name === 'token')
+    const refreshTokenCookie = cookies.find((c) => c.name === 'refreshToken')
 
     // If no cookie is set, login might have failed
     if (!tokenCookie) {
@@ -44,21 +51,97 @@ test.describe('JWT Expiration', () => {
       )
     }
 
+    // Assert
     expect(tokenCookie).toBeTruthy()
+    expect(refreshTokenCookie).toBeTruthy()
 
-    // Check that cookie expiration is approximately 7 days from now
+    // Check that the access cookie expiration is approximately one hour from now.
     const expirationDate = new Date(tokenCookie.expires * 1000)
     const now = new Date()
-    const diffInDays =
-      (expirationDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+    const diffInHours =
+      (expirationDate.getTime() - now.getTime()) / (1000 * 60 * 60)
 
-    // Allow for some variance
-    expect(diffInDays).toBeGreaterThan(6.9)
-    expect(diffInDays).toBeLessThan(7.1)
+    expect(diffInHours).toBeGreaterThan(0.9)
+    expect(diffInHours).toBeLessThan(1.1)
+
+    const refreshExpirationDate = new Date(refreshTokenCookie!.expires * 1000)
+    const refreshDiffInDays =
+      (refreshExpirationDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24)
+
+    expect(refreshDiffInDays).toBeGreaterThan(6.9)
+    expect(refreshDiffInDays).toBeLessThan(7.1)
 
     // Verify we're logged in - check for menu button first
     await page.keyboard.press('x')
     await expect(page.getByTestId('dashboard-link')).toBeVisible()
+  })
+
+  test('expired access cookie rotates through a valid refresh cookie', async ({
+    page,
+    context,
+  }) => {
+    // Arrange
+    await page.goto('http://localhost:3010')
+    await page.keyboard.press('x')
+    await page.getByTestId('login-link').click()
+    await page.getByTestId('name-input').fill('John Doe')
+    await page.getByTestId('password-input').fill('popcoon')
+
+    const loginResponsePromise = page.waitForResponse('**/login')
+    await page.getByTestId('submit-btn').click()
+    const loginResponse = await loginResponsePromise
+
+    expect(loginResponse.status()).toBe(200)
+
+    const originalCookies = await context.cookies()
+    const originalTokenCookie = originalCookies.find((c) => c.name === 'token')
+    const originalRefreshCookie = originalCookies.find(
+      (c) => c.name === 'refreshToken',
+    )
+
+    expect(originalTokenCookie).toBeTruthy()
+    expect(originalRefreshCookie).toBeTruthy()
+
+    const expiredAccessToken = jwt.sign(
+      {
+        id: 1,
+        name: 'John Doe',
+        password: JOHN_DOE_PASSWORD_HASH,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        useLegacyHoverColors: false,
+      },
+      process.env.ACCESS_TOKEN_SECRET!,
+      { expiresIn: '-1s' },
+    )
+
+    await context.addCookies([
+      {
+        ...originalTokenCookie!,
+        value: expiredAccessToken,
+        expires: Math.floor(Date.now() / 1000) + 60 * 60,
+      },
+    ])
+
+    // Act
+    const validateResponse = await page
+      .context()
+      .request.get(`${API_BASE_URL}/validate`)
+    const validateBody = await validateResponse.json()
+    const rotatedCookies = await context.cookies()
+    const rotatedTokenCookie = rotatedCookies.find((c) => c.name === 'token')
+    const rotatedRefreshCookie = rotatedCookies.find(
+      (c) => c.name === 'refreshToken',
+    )
+
+    // Assert
+    expect(validateResponse.status()).toBe(200)
+    expect(validateBody).toMatchObject({
+      valid: true,
+      user: { id: 1, name: 'John Doe' },
+    })
+    expect(rotatedTokenCookie?.value).not.toBe(expiredAccessToken)
+    expect(rotatedRefreshCookie?.value).not.toBe(originalRefreshCookie?.value)
   })
 
   test('expired JWT token should redirect to login', async ({
@@ -153,10 +236,12 @@ test.describe('JWT Expiration', () => {
     // Wait for logout to complete and navigation
     await page.waitForLoadState('networkidle')
 
-    // Verify cookie is cleared
+    // Verify cookies are cleared
     cookies = await context.cookies()
     const tokenCookie = cookies.find((c) => c.name === 'token')
+    const refreshTokenCookie = cookies.find((c) => c.name === 'refreshToken')
     expect(!tokenCookie || tokenCookie.value === '').toBeTruthy()
+    expect(!refreshTokenCookie || refreshTokenCookie.value === '').toBeTruthy()
 
     // Verify we're redirected to home page after logout
     await expect(page).toHaveURL('http://localhost:3010/')

--- a/e2e/admin/authorization.spec.ts
+++ b/e2e/admin/authorization.spec.ts
@@ -1,0 +1,118 @@
+import { exec as execCb } from 'node:child_process'
+import util from 'node:util'
+
+import { expect, type BrowserContext } from '@playwright/test'
+
+import { test } from '../helper'
+
+const exec = util.promisify(execCb)
+const API_BASE_URL = 'http://localhost:4000/api'
+
+test.beforeAll(async () => {
+  await exec('PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset')
+})
+
+/**
+ * Logs a browser context in through the API so its request context stores auth cookies.
+ *
+ * Called by authorization tests that need two isolated users.
+ *
+ * @param context - Playwright browser context that owns the request cookies.
+ * @param name - Seeded username to authenticate as.
+ * @returns Nothing after the login response has set cookies.
+ * @example await loginAs(context, 'John Doe')
+ */
+const loginAs = async (
+  context: BrowserContext,
+  name: string,
+): Promise<void> => {
+  const response = await context.request.post(`${API_BASE_URL}/login`, {
+    data: { name, password: 'popcoon' },
+  })
+
+  expect(response.status()).toBe(200)
+}
+
+test.describe('API authorization', () => {
+  test('rejects unauthenticated stock and tweet mutations', async ({
+    page,
+  }) => {
+    // Arrange
+    const validStockPayload = {
+      pageTitle: 'Readable page',
+      url: 'https://example.com/readable-page',
+    }
+
+    // Act
+    const stockResponse = await page
+      .context()
+      .request.post(`${API_BASE_URL}/push_stock`, {
+        data: validStockPayload,
+      })
+    const stockListResponse = await page
+      .context()
+      .request.get(`${API_BASE_URL}/stocklist`)
+    const tweetDeleteResponse = await page
+      .context()
+      .request.delete(`${API_BASE_URL}/tweet/1`)
+
+    // Assert
+    expect(stockResponse.status()).toBe(401)
+    expect(await stockResponse.json()).toEqual({ error: 'No token found' })
+    expect(stockListResponse.status()).toBe(401)
+    expect(await stockListResponse.json()).toEqual({ error: 'No token found' })
+    expect(tweetDeleteResponse.status()).toBe(401)
+    expect(await tweetDeleteResponse.json()).toEqual({
+      error: 'No token found',
+    })
+  })
+
+  test('prevents one user from deleting another user resources', async ({
+    browser,
+  }) => {
+    // Arrange
+    const johnContext = await browser.newContext()
+    const rexContext = await browser.newContext()
+
+    await loginAs(johnContext, 'John Doe')
+    await loginAs(rexContext, 'rex')
+
+    const stockResponse = await johnContext.request.post(
+      `${API_BASE_URL}/push_stock`,
+      {
+        data: {
+          pageTitle: 'Owned stock page',
+          url: 'https://example.com/owned-stock-page',
+        },
+      },
+    )
+    const stock = (await stockResponse.json()) as Stock
+
+    // Act
+    const postDeleteResponse = await rexContext.request.delete(
+      `${API_BASE_URL}/post/1`,
+    )
+    const stockDeleteResponse = await rexContext.request.delete(
+      `${API_BASE_URL}/stock/${stock.id}`,
+    )
+    const tweetDeleteResponse = await rexContext.request.delete(
+      `${API_BASE_URL}/tweet/1`,
+    )
+
+    // Assert
+    expect(stockResponse.status()).toBe(201)
+    expect(postDeleteResponse.status()).toBe(403)
+    expect(await postDeleteResponse.json()).toEqual({ message: 'Forbidden' })
+    expect(stockDeleteResponse.status()).toBe(403)
+    expect(await stockDeleteResponse.json()).toEqual({ message: 'Forbidden' })
+    expect(tweetDeleteResponse.status()).toBe(403)
+    expect(await tweetDeleteResponse.json()).toEqual({ message: 'Forbidden' })
+
+    await johnContext.close()
+    await rexContext.close()
+  })
+})
+
+test.afterAll(async () => {
+  await exec('PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset')
+})

--- a/e2e/admin/authorization.spec.ts
+++ b/e2e/admin/authorization.spec.ts
@@ -86,7 +86,9 @@ test.describe('API authorization', () => {
         },
       },
     )
+    expect(stockResponse.status()).toBe(201)
     const stock = (await stockResponse.json()) as Stock
+    expect(stock.id).toBeDefined()
 
     // Act
     const postDeleteResponse = await rexContext.request.delete(
@@ -100,13 +102,12 @@ test.describe('API authorization', () => {
     )
 
     // Assert
-    expect(stockResponse.status()).toBe(201)
     expect(postDeleteResponse.status()).toBe(403)
-    expect(await postDeleteResponse.json()).toEqual({ message: 'Forbidden' })
+    expect(await postDeleteResponse.json()).toEqual({ error: 'Forbidden' })
     expect(stockDeleteResponse.status()).toBe(403)
-    expect(await stockDeleteResponse.json()).toEqual({ message: 'Forbidden' })
+    expect(await stockDeleteResponse.json()).toEqual({ error: 'Forbidden' })
     expect(tweetDeleteResponse.status()).toBe(403)
-    expect(await tweetDeleteResponse.json()).toEqual({ message: 'Forbidden' })
+    expect(await tweetDeleteResponse.json()).toEqual({ error: 'Forbidden' })
 
     await johnContext.close()
     await rexContext.close()

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -133,7 +133,7 @@ export const handlers = [
   http.post('http://*/login', async () => {
     return HttpResponse.json([])
   }),
-  http.get('http://*/logout', async () => {
+  http.post('http://*/logout', async () => {
     return HttpResponse.json([])
   }),
   http.post('http://*/create', async () => {
@@ -154,7 +154,7 @@ export const handlers = [
   http.post('http://*/api/login', async () => {
     return HttpResponse.json([])
   }),
-  http.get('http://*/api/logout', async () => {
+  http.post('http://*/api/logout', async () => {
     return HttpResponse.json([])
   }),
   http.delete('http://*/api/post/:id', async () => {

--- a/mocks/handlers.ts
+++ b/mocks/handlers.ts
@@ -134,7 +134,7 @@ export const handlers = [
     return HttpResponse.json([])
   }),
   http.post('http://*/logout', async () => {
-    return HttpResponse.json([])
+    return HttpResponse.json({ success: true })
   }),
   http.post('http://*/create', async () => {
     return HttpResponse.json([])
@@ -155,7 +155,7 @@ export const handlers = [
     return HttpResponse.json([])
   }),
   http.post('http://*/api/logout', async () => {
-    return HttpResponse.json([])
+    return HttpResponse.json({ success: true })
   }),
   http.delete('http://*/api/post/:id', async () => {
     return HttpResponse.json([])

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -77,6 +77,8 @@ export default defineConfig({
       reuseExistingServer: !process.env.CI,
       env: {
         ACCESS_TOKEN_SECRET: process.env.ACCESS_TOKEN_SECRET!,
+        REFRESH_TOKEN_SECRET:
+          process.env.REFRESH_TOKEN_SECRET ?? process.env.ACCESS_TOKEN_SECRET!,
         OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
         BLUESKY_USERNAME: process.env.BLUESKY_USERNAME!,
         BLUESKY_PASSWORD: process.env.BLUESKY_PASSWORD!,

--- a/prisma/migrations/20260527034000_add_resource_ownership_and_refresh_tokens/migration.sql
+++ b/prisma/migrations/20260527034000_add_resource_ownership_and_refresh_tokens/migration.sql
@@ -15,6 +15,9 @@ CREATE TABLE `refresh_tokens` (
 ) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
 
 -- AlterTable
+ALTER TABLE `authors` ADD COLUMN `sessionVersion` INTEGER NOT NULL DEFAULT 0;
+
+-- AlterTable
 ALTER TABLE `posts` ADD COLUMN `authorId` INTEGER NULL;
 
 -- AlterTable
@@ -24,16 +27,32 @@ ALTER TABLE `stocks` ADD COLUMN `userId` INTEGER NULL;
 ALTER TABLE `tweet` ADD COLUMN `userId` INTEGER NULL;
 
 -- Backfill existing personal content to the first account before enforcing ownership.
+SET @fallback_author_id = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1);
+SET @owned_content_count = (
+    (SELECT COUNT(*) FROM `posts`) +
+    (SELECT COUNT(*) FROM `stocks`) +
+    (SELECT COUNT(*) FROM `tweet`)
+);
+
+-- Abort explicitly if legacy owned content exists but no author can own it.
+CREATE TEMPORARY TABLE `_nsx_author_backfill_guard` (`id` INTEGER NOT NULL);
+INSERT INTO `_nsx_author_backfill_guard` (`id`)
+SELECT CASE
+    WHEN @fallback_author_id IS NULL AND @owned_content_count > 0 THEN NULL
+    ELSE 0
+END;
+DROP TEMPORARY TABLE `_nsx_author_backfill_guard`;
+
 UPDATE `posts`
-SET `authorId` = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1)
+SET `authorId` = @fallback_author_id
 WHERE `authorId` IS NULL;
 
 UPDATE `stocks`
-SET `userId` = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1)
+SET `userId` = @fallback_author_id
 WHERE `userId` IS NULL;
 
 UPDATE `tweet`
-SET `userId` = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1)
+SET `userId` = @fallback_author_id
 WHERE `userId` IS NULL;
 
 -- AlterTable

--- a/prisma/migrations/20260527034000_add_resource_ownership_and_refresh_tokens/migration.sql
+++ b/prisma/migrations/20260527034000_add_resource_ownership_and_refresh_tokens/migration.sql
@@ -1,0 +1,67 @@
+-- CreateTable
+CREATE TABLE `refresh_tokens` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `tokenHash` CHAR(64) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `expiresAt` DATETIME(3) NOT NULL,
+    `revokedAt` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `refresh_tokens_tokenHash_key`(`tokenHash`),
+    INDEX `refresh_tokens_userId_idx`(`userId`),
+    INDEX `refresh_tokens_expiresAt_idx`(`expiresAt`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AlterTable
+ALTER TABLE `posts` ADD COLUMN `authorId` INTEGER NULL;
+
+-- AlterTable
+ALTER TABLE `stocks` ADD COLUMN `userId` INTEGER NULL;
+
+-- AlterTable
+ALTER TABLE `tweet` ADD COLUMN `userId` INTEGER NULL;
+
+-- Backfill existing personal content to the first account before enforcing ownership.
+UPDATE `posts`
+SET `authorId` = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1)
+WHERE `authorId` IS NULL;
+
+UPDATE `stocks`
+SET `userId` = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1)
+WHERE `userId` IS NULL;
+
+UPDATE `tweet`
+SET `userId` = (SELECT `id` FROM `authors` ORDER BY `id` ASC LIMIT 1)
+WHERE `userId` IS NULL;
+
+-- AlterTable
+ALTER TABLE `posts` MODIFY `authorId` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `stocks` MODIFY `userId` INTEGER NOT NULL;
+
+-- AlterTable
+ALTER TABLE `tweet` MODIFY `userId` INTEGER NOT NULL;
+
+-- CreateIndex
+CREATE INDEX `posts_authorId_idx` ON `posts`(`authorId`);
+
+-- CreateIndex
+CREATE INDEX `stocks_userId_idx` ON `stocks`(`userId`);
+
+-- CreateIndex
+CREATE INDEX `tweet_userId_idx` ON `tweet`(`userId`);
+
+-- AddForeignKey
+ALTER TABLE `refresh_tokens` ADD CONSTRAINT `refresh_tokens_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `authors`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `posts` ADD CONSTRAINT `posts_authorId_fkey` FOREIGN KEY (`authorId`) REFERENCES `authors`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `stocks` ADD CONSTRAINT `stocks_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `authors`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `tweet` ADD CONSTRAINT `tweet_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `authors`(`id`) ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -12,12 +12,13 @@ model User {
   name                 String         @db.VarChar(255)
   createdAt            DateTime       @default(now())
   password             String         @db.Text
+  sessionVersion       Int            @default(0)
   updatedAt            DateTime       @updatedAt
   useLegacyHoverColors Boolean        @default(false)
   posts                Post[]
   refreshTokens        RefreshToken[]
   stocks               Stock[]
-  tweets               tweet[]
+  tweets               Tweet[]
 
   @@map("authors")
 }
@@ -48,7 +49,7 @@ model Stock {
   @@map("stocks")
 }
 
-model tweet {
+model Tweet {
   id          Int          @id @default(autoincrement())
   createdAt   DateTime     @default(now())
   updatedAt   DateTime     @updatedAt
@@ -58,13 +59,14 @@ model tweet {
   user        User         @relation(fields: [userId], references: [id], onDelete: Restrict)
 
   @@index([userId])
+  @@map("tweet")
 }
 
 model attachment {
   id      Int    @id @default(autoincrement())
   url     String @db.Text
   tweetId Int
-  tweet   tweet  @relation(fields: [tweetId], references: [id], onDelete: Cascade)
+  tweet   Tweet  @relation(fields: [tweetId], references: [id], onDelete: Cascade)
 }
 
 model RefreshToken {

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,23 +8,30 @@ datasource db {
 }
 
 model User {
-  id                    Int      @id @default(autoincrement())
-  name                  String   @db.VarChar(255)
-  createdAt             DateTime @default(now())
-  password              String   @db.Text
-  updatedAt             DateTime @updatedAt
-  useLegacyHoverColors  Boolean  @default(false)
+  id                   Int            @id @default(autoincrement())
+  name                 String         @db.VarChar(255)
+  createdAt            DateTime       @default(now())
+  password             String         @db.Text
+  updatedAt            DateTime       @updatedAt
+  useLegacyHoverColors Boolean        @default(false)
+  posts                Post[]
+  refreshTokens        RefreshToken[]
+  stocks               Stock[]
+  tweets               tweet[]
 
   @@map("authors")
 }
 
 model Post {
   id        Int      @id @default(autoincrement())
+  authorId  Int
   title     String   @db.VarChar(400)
   body      String   @db.Text
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
+  author    User     @relation(fields: [authorId], references: [id], onDelete: Restrict)
 
+  @@index([authorId])
   @@map("posts")
 }
 
@@ -34,21 +41,43 @@ model Stock {
   pageTitle String   @db.Text
   updatedAt DateTime @updatedAt
   url       String   @db.Text
+  userId    Int
+  user      User     @relation(fields: [userId], references: [id], onDelete: Restrict)
 
+  @@index([userId])
   @@map("stocks")
 }
 
 model tweet {
-  id          Int           @id @default(autoincrement())
-  createdAt   DateTime      @default(now())
-  updatedAt   DateTime      @updatedAt
-  text        String        @db.Text
+  id          Int          @id @default(autoincrement())
+  createdAt   DateTime     @default(now())
+  updatedAt   DateTime     @updatedAt
+  text        String       @db.Text
+  userId      Int
   attachments attachment[]
+  user        User         @relation(fields: [userId], references: [id], onDelete: Restrict)
+
+  @@index([userId])
 }
 
 model attachment {
-  id       Int    @id @default(autoincrement())
-  url      String @db.Text
-  tweetId  Int
-  tweet    tweet  @relation(fields: [tweetId], references: [id], onDelete: Cascade)
+  id      Int    @id @default(autoincrement())
+  url     String @db.Text
+  tweetId Int
+  tweet   tweet  @relation(fields: [tweetId], references: [id], onDelete: Cascade)
+}
+
+model RefreshToken {
+  id        Int       @id @default(autoincrement())
+  tokenHash String    @unique @db.Char(64)
+  userId    Int
+  expiresAt DateTime
+  revokedAt DateTime?
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
+  user      User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@index([expiresAt])
+  @@map("refresh_tokens")
 }

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -263,17 +263,9 @@ async function main() {
     },
   ]
   /*
-   * Post Seed
-   */
-  for (const post of posts) {
-    await prisma.post.create({
-      data: post,
-    })
-  }
-  /*
    * User Seed
    */
-  await prisma.user.create({
+  const primaryUser = await prisma.user.create({
     data: {
       name: 'John Doe',
       // hash of 'popcoon',
@@ -287,6 +279,17 @@ async function main() {
       password: '$2b$10$PDIcmRmxvgVeIaa/c9AWiu4wRQD7EwBjczFqVDjgMtsj4.To0W5aC',
     },
   })
+  /*
+   * Post Seed
+   */
+  for (const post of posts) {
+    await prisma.post.create({
+      data: {
+        ...post,
+        authorId: primaryUser.id,
+      },
+    })
+  }
   /*
    * Tweet Seed
    */
@@ -369,7 +372,10 @@ async function main() {
   ]
   for (const tweet of tweets) {
     await prisma.tweet.create({
-      data: tweet,
+      data: {
+        ...tweet,
+        userId: primaryUser.id,
+      },
     })
   }
 }

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,9 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
-import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 
-import { verifyAccessToken } from './lib/JWT'
+import { authenticateRequestSession } from './lib/authSession'
 import Logger from './lib/Logger'
-import { prisma } from './prisma'
 
 /**
  * Verifies the cookie JWT before protected API route handlers run.
@@ -22,52 +20,18 @@ export const isAuthorized = async (
   res: Response,
   next: NextFunction,
 ): Promise<void> => {
-  const token = req.cookies.token as JWTtoken
-
-  if (!token) {
-    res.status(401).json({ error: 'No token found' })
-    return
-  }
-
   try {
-    const decripted = verifyAccessToken(token) as User & { password: string }
-    const user = await prisma.user.findFirst({
-      where: {
-        id: decripted.id,
-        password: decripted.password,
-      },
-    })
-    // JWT user exist
-    if (user) {
-      // Verified
-      return next()
-    } else {
-      Logger.info('Stale session rejected', { userId: decripted.id })
-      // A stale session must be treated as logged out so the client can re-authenticate.
-      res.cookie('token', '', { expires: new Date() })
-      res.status(401).json({ error: 'Invalid or expired token' })
+    const session = await authenticateRequestSession(req, res)
+
+    if (!session.ok) {
+      res.status(session.status).json({ error: session.message })
       return
     }
+
+    req.authenticatedUser = session.user
+    return next()
   } catch (error) {
-    Logger.error('failed jwt.verify()')
-
-    // Expired path
-    if (
-      error instanceof TokenExpiredError ||
-      error instanceof JsonWebTokenError
-    ) {
-      Logger.info('Invalid or expired token')
-      // Clear cookie
-      res.cookie('token', '', { expires: new Date() })
-      res.status(401).json({ error: 'Invalid or expired token' })
-      return
-    }
-
-    Logger.error('Database Connection Error')
     Logger.error(error)
-
-    // Clear cookie
-    res.cookie('token', '', { expires: new Date() })
-    res.status(500).json({ error: 'Database Connection Error' })
+    res.status(500).json({ error: 'Authentication failed' })
   }
 }

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -9,22 +9,42 @@ export const Cron: CronInterface = {
   readList: new CronJob('0 0 * * *', postReadlist, null, true, 'Asia/Tokyo'),
 }
 
+/**
+ * Converts each user's saved stock list into a daily post.
+ *
+ * Triggered by the midnight cron job; groups rows by owner so resource
+ * ownership remains intact when stocks become posts.
+ *
+ * @returns Nothing after all pending stock rows are posted and cleared.
+ * @example await postReadlist()
+ */
 async function postReadlist() {
   const stocks = await prisma.stock.findMany()
   if (stocks.length === 0) return
 
-  const title = stocks[0].pageTitle + ' etc...'
+  const stocksByUser = new Map<number, typeof stocks>()
 
-  let body = ''
   for (const stock of stocks) {
-    body += `[${stock.pageTitle}](${stock.url})  \n\n`
+    const userStocks = stocksByUser.get(stock.userId) ?? []
+    userStocks.push(stock)
+    stocksByUser.set(stock.userId, userStocks)
   }
 
-  await prisma.post.create({
-    data: {
-      title: title,
-      body: body,
-    },
-  })
-  await prisma.stock.deleteMany()
+  for (const [userId, userStocks] of stocksByUser) {
+    const title = userStocks[0].pageTitle + ' etc...'
+    let body = ''
+
+    for (const stock of userStocks) {
+      body += `[${stock.pageTitle}](${stock.url})  \n\n`
+    }
+
+    await prisma.post.create({
+      data: {
+        authorId: userId,
+        title: title,
+        body: body,
+      },
+    })
+    await prisma.stock.deleteMany({ where: { userId } })
+  }
 }

--- a/server/cron.ts
+++ b/server/cron.ts
@@ -38,13 +38,15 @@ async function postReadlist() {
       body += `[${stock.pageTitle}](${stock.url})  \n\n`
     }
 
-    await prisma.post.create({
-      data: {
-        authorId: userId,
-        title: title,
-        body: body,
-      },
-    })
-    await prisma.stock.deleteMany({ where: { userId } })
+    await prisma.$transaction([
+      prisma.post.create({
+        data: {
+          authorId: userId,
+          title,
+          body,
+        },
+      }),
+      prisma.stock.deleteMany({ where: { userId } }),
+    ])
   }
 }

--- a/server/lib/JWT.test.ts
+++ b/server/lib/JWT.test.ts
@@ -72,11 +72,35 @@ describe('JWT Functions', () => {
         sessionVersion: 0,
         sub: '1',
       })
+      expect(decoded.jti).toEqual(expect.any(String))
       expect(decoded.password).toBeUndefined()
 
       const expectedExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
       expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 10)
       expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 10)
+    })
+
+    it('uses unique token IDs so same-second refresh rotations do not collide', () => {
+      // Arrange
+      const user = {
+        id: 1,
+        name: 'Test User',
+        password: 'hashed',
+        sessionVersion: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        useLegacyHoverColors: false,
+      }
+
+      // Act
+      const firstToken = generateRefreshToken(user)
+      const secondToken = generateRefreshToken(user)
+      const firstDecoded = jwt.decode(firstToken) as any
+      const secondDecoded = jwt.decode(secondToken) as any
+
+      // Assert
+      expect(secondToken).not.toBe(firstToken)
+      expect(secondDecoded.jti).not.toBe(firstDecoded.jti)
     })
   })
 

--- a/server/lib/JWT.test.ts
+++ b/server/lib/JWT.test.ts
@@ -6,6 +6,7 @@ import {
   generateAccessToken,
   getTokenExpiration,
   getCookieOptions,
+  getRefreshCookieOptions,
 } from './JWT'
 
 // Mock environment variable
@@ -20,6 +21,7 @@ describe('JWT Functions', () => {
         id: 1,
         name: 'Test User',
         password: 'hashed',
+        sessionVersion: 0,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         useLegacyHoverColors: false,
@@ -32,6 +34,12 @@ describe('JWT Functions', () => {
       // Assert
       expect(decoded).toBeTruthy()
       expect(decoded.exp).toBeTruthy()
+      expect(decoded).toMatchObject({
+        kind: 'access',
+        sessionVersion: 0,
+        sub: '1',
+      })
+      expect(decoded.password).toBeUndefined()
 
       const expectedExp = Math.floor(Date.now() / 1000) + 60 * 60
       expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 10)
@@ -46,6 +54,7 @@ describe('JWT Functions', () => {
         id: 1,
         name: 'Test User',
         password: 'hashed',
+        sessionVersion: 0,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         useLegacyHoverColors: false,
@@ -58,6 +67,12 @@ describe('JWT Functions', () => {
       // Assert
       expect(decoded).toBeTruthy()
       expect(decoded.exp).toBeTruthy()
+      expect(decoded).toMatchObject({
+        kind: 'refresh',
+        sessionVersion: 0,
+        sub: '1',
+      })
+      expect(decoded.password).toBeUndefined()
 
       const expectedExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
       expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 10)
@@ -72,6 +87,7 @@ describe('JWT Functions', () => {
         id: 1,
         name: 'Test User',
         password: 'hashed',
+        sessionVersion: 0,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         useLegacyHoverColors: false,
@@ -110,6 +126,7 @@ describe('JWT Functions', () => {
         id: 1,
         name: 'Test User',
         password: 'hashed',
+        sessionVersion: 0,
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
         useLegacyHoverColors: false,
@@ -145,6 +162,30 @@ describe('JWT Functions', () => {
 
       // Assert
       expect(options.maxAge).toBe(0)
+    })
+
+    it('uses strict sameSite for refresh cookies', () => {
+      // Arrange
+      const user = {
+        id: 1,
+        name: 'Test User',
+        password: 'hashed',
+        sessionVersion: 0,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        useLegacyHoverColors: false,
+      }
+
+      // Act
+      const token = generateRefreshToken(user)
+      const options = getRefreshCookieOptions(token)
+
+      // Assert
+      expect(options.httpOnly).toBe(true)
+      expect(options.secure).toBe(false)
+      expect(options.sameSite).toBe('strict')
+      expect(options.maxAge).toBeGreaterThan(7 * 24 * 60 * 60 * 1000 - 10000)
+      expect(options.maxAge).toBeLessThan(7 * 24 * 60 * 60 * 1000 + 10000)
     })
   })
 })

--- a/server/lib/JWT.test.ts
+++ b/server/lib/JWT.test.ts
@@ -2,6 +2,7 @@ import jwt from 'jsonwebtoken'
 import { describe, it, expect, vi } from 'vitest'
 
 import {
+  generateRefreshToken,
   generateAccessToken,
   getTokenExpiration,
   getCookieOptions,
@@ -9,10 +10,12 @@ import {
 
 // Mock environment variable
 vi.stubEnv('ACCESS_TOKEN_SECRET', 'test-secret')
+vi.stubEnv('REFRESH_TOKEN_SECRET', 'test-refresh-secret')
 
 describe('JWT Functions', () => {
   describe('generateAccessToken', () => {
-    it('should generate a token with 7 day expiration', () => {
+    it('sets access tokens to expire after one hour', () => {
+      // Arrange
       const user = {
         id: 1,
         name: 'Test User',
@@ -22,21 +25,49 @@ describe('JWT Functions', () => {
         useLegacyHoverColors: false,
       }
 
+      // Act
       const token = generateAccessToken(user)
       const decoded = jwt.decode(token) as any
 
+      // Assert
       expect(decoded).toBeTruthy()
       expect(decoded.exp).toBeTruthy()
 
-      // Check that expiration is approximately 7 days from now
+      const expectedExp = Math.floor(Date.now() / 1000) + 60 * 60
+      expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 10)
+      expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 10)
+    })
+  })
+
+  describe('generateRefreshToken', () => {
+    it('sets refresh tokens to expire after seven days', () => {
+      // Arrange
+      const user = {
+        id: 1,
+        name: 'Test User',
+        password: 'hashed',
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+        useLegacyHoverColors: false,
+      }
+
+      // Act
+      const token = generateRefreshToken(user)
+      const decoded = jwt.decode(token) as any
+
+      // Assert
+      expect(decoded).toBeTruthy()
+      expect(decoded.exp).toBeTruthy()
+
       const expectedExp = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60
-      expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 10) // Allow 10 second variance
+      expect(decoded.exp).toBeGreaterThanOrEqual(expectedExp - 10)
       expect(decoded.exp).toBeLessThanOrEqual(expectedExp + 10)
     })
   })
 
   describe('getTokenExpiration', () => {
-    it('should extract expiration date from JWT token', () => {
+    it('extracts expiration date from a signed access token', () => {
+      // Arrange
       const user = {
         id: 1,
         name: 'Test User',
@@ -46,32 +77,35 @@ describe('JWT Functions', () => {
         useLegacyHoverColors: false,
       }
 
+      // Act
       const token = generateAccessToken(user)
       const expiration = getTokenExpiration(token)
 
-      // Should be approximately 7 days from now
-      const expectedDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      // Assert
+      const expectedDate = new Date(Date.now() + 60 * 60 * 1000)
       const timeDiff = Math.abs(expiration.getTime() - expectedDate.getTime())
 
-      // Allow 10 second variance
       expect(timeDiff).toBeLessThan(10000)
     })
 
-    it('should return default expiration for invalid token', () => {
+    it('defaults invalid token expiration to one hour', () => {
+      // Arrange
       const invalidToken = 'invalid.token.here'
+
+      // Act
       const expiration = getTokenExpiration(invalidToken)
 
-      // Should be approximately 7 days from now
-      const expectedDate = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+      // Assert
+      const expectedDate = new Date(Date.now() + 60 * 60 * 1000)
       const timeDiff = Math.abs(expiration.getTime() - expectedDate.getTime())
 
-      // Allow 10 second variance
       expect(timeDiff).toBeLessThan(10000)
     })
   })
 
   describe('getCookieOptions', () => {
-    it('should return cookie options with correct expiration', () => {
+    it('aligns the cookie lifetime with the access token lifetime', () => {
+      // Arrange
       const user = {
         id: 1,
         name: 'Test User',
@@ -81,33 +115,35 @@ describe('JWT Functions', () => {
         useLegacyHoverColors: false,
       }
 
+      // Act
       const token = generateAccessToken(user)
       const options = getCookieOptions(token)
 
+      // Assert
       expect(options.httpOnly).toBe(true)
-      expect(options.secure).toBe(true)
-      expect(options.sameSite).toBe('none')
+      expect(options.secure).toBe(false)
+      expect(options.sameSite).toBe('lax')
       expect(options.expires).toBeInstanceOf(Date)
       expect(options.maxAge).toBeGreaterThan(0)
 
-      // maxAge should be approximately 7 days in milliseconds
-      const expectedMaxAge = 7 * 24 * 60 * 60 * 1000
-      expect(options.maxAge).toBeGreaterThan(expectedMaxAge - 10000) // Allow 10 second variance
+      const expectedMaxAge = 60 * 60 * 1000
+      expect(options.maxAge).toBeGreaterThan(expectedMaxAge - 10000)
       expect(options.maxAge).toBeLessThan(expectedMaxAge + 10000)
     })
 
-    it('should handle expired tokens gracefully', () => {
-      // Create a token that's already expired
+    it('sets zero maxAge for expired tokens', () => {
+      // Arrange
       const expiredPayload = {
         id: 1,
         name: 'Test User',
-        exp: Math.floor(Date.now() / 1000) - 3600, // Expired 1 hour ago
+        exp: Math.floor(Date.now() / 1000) - 3600,
       }
 
+      // Act
       const expiredToken = jwt.sign(expiredPayload, 'test-secret')
       const options = getCookieOptions(expiredToken)
 
-      // maxAge should be 0 for expired tokens
+      // Assert
       expect(options.maxAge).toBe(0)
     })
   })

--- a/server/lib/JWT.ts
+++ b/server/lib/JWT.ts
@@ -3,6 +3,11 @@ import jwt, { type JwtPayload, TokenExpiredError } from 'jsonwebtoken'
 
 import type { User } from '../../generated/prisma/client'
 
+export const ACCESS_TOKEN_COOKIE_NAME = 'token'
+export const REFRESH_TOKEN_COOKIE_NAME = 'refreshToken'
+export const ACCESS_TOKEN_EXPIRES_IN = '1h'
+export const REFRESH_TOKEN_EXPIRES_IN = '7d'
+
 /**
  * Extended User type that represents the user returned from Prisma with extensions.
  * The Prisma extension converts createdAt and updatedAt from Date to string.
@@ -12,10 +17,50 @@ type ExtendedUser = Omit<User, 'createdAt' | 'updatedAt'> & {
   updatedAt: Date | string
 }
 
-// Generate Access Token
-export function generateAccessToken(user: ExtendedUser) {
+/**
+ * Returns the secret used to sign refresh tokens.
+ *
+ * Called when issuing or verifying refresh cookies; falls back to the access
+ * token secret so existing environments keep working until configured.
+ *
+ * @returns Refresh-token signing secret.
+ * @example getRefreshTokenSecret()
+ */
+const getRefreshTokenSecret = (): string => {
+  return (
+    process.env.REFRESH_TOKEN_SECRET ??
+    (process.env.ACCESS_TOKEN_SECRET as string)
+  )
+}
+
+/**
+ * Generate the short-lived access token stored in the `token` cookie.
+ *
+ * Called by login, signup, and refresh rotation after a user is authenticated.
+ *
+ * @param user - User record used as the JWT payload.
+ * @returns Signed JWT that expires after one hour.
+ * @example generateAccessToken(user)
+ */
+export function generateAccessToken(user: ExtendedUser): JWTtoken {
   return jwt.sign(user, process.env.ACCESS_TOKEN_SECRET as string, {
-    expiresIn: '7d',
+    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+  })
+}
+
+/**
+ * Generate the longer-lived refresh token stored in the `refreshToken` cookie.
+ *
+ * Called together with `generateAccessToken` and persisted by hashed value so
+ * old refresh cookies can be revoked during rotation.
+ *
+ * @param user - User record used as the refresh JWT payload.
+ * @returns Signed JWT that expires after seven days.
+ * @example generateRefreshToken(user)
+ */
+export function generateRefreshToken(user: ExtendedUser): JWTtoken {
+  return jwt.sign(user, getRefreshTokenSecret(), {
+    expiresIn: REFRESH_TOKEN_EXPIRES_IN,
   })
 }
 
@@ -26,8 +71,8 @@ export function getTokenExpiration(token: string): Date {
     // exp is in seconds, convert to milliseconds
     return new Date(decoded.exp * 1000)
   }
-  // Default to 7 days if no exp claim
-  return new Date(Date.now() + 7 * 24 * 60 * 60 * 1000)
+  // Default to one hour if no exp claim is present.
+  return new Date(Date.now() + 60 * 60 * 1000)
 }
 
 // Verify Access Token
@@ -45,6 +90,20 @@ export function verifyAccessToken(token: string): JwtPayload {
     // Other errors are simply rethrown
     throw error
   }
+}
+
+/**
+ * Verify a refresh token with the refresh-token secret.
+ *
+ * Called only by the refresh rotation path before checking the hashed token in
+ * the database.
+ *
+ * @param token - Refresh JWT read from the `refreshToken` cookie.
+ * @returns Verified JWT payload.
+ * @example verifyRefreshToken(refreshToken)
+ */
+export function verifyRefreshToken(token: string): JwtPayload {
+  return jwt.verify(token, getRefreshTokenSecret()) as JwtPayload
 }
 
 export function deleteJWTattribute(payload: JwtPayload) {
@@ -71,4 +130,17 @@ export function getCookieOptions(token: string): CookieOptions {
     sameSite: 'lax',
     secure: isProduction,
   }
+}
+
+/**
+ * Builds cookie options for refresh-token cookies.
+ *
+ * Called when login/signup/refresh set the longer-lived refresh cookie.
+ *
+ * @param token - Refresh token whose expiration should drive the cookie.
+ * @returns HTTP-only cookie options matching the refresh token lifetime.
+ * @example getRefreshCookieOptions(refreshToken)
+ */
+export function getRefreshCookieOptions(token: string): CookieOptions {
+  return getCookieOptions(token)
 }

--- a/server/lib/JWT.ts
+++ b/server/lib/JWT.ts
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto'
+
 import type { CookieOptions } from 'express'
 import jwt, {
   JsonWebTokenError,
@@ -45,10 +47,11 @@ const getRefreshTokenSecret = (): string => {
 }
 
 /**
- * Builds the minimal JWT payload shared by access and refresh tokens.
+ * Builds the minimal user JWT payload shared by access and refresh tokens.
  *
  * Called before signing so password hashes and other user fields never leave
- * the server in a readable JWT body.
+ * the server in a readable JWT body; refresh-token uniqueness is added with
+ * the standard `jti` claim during signing.
  *
  * @param user - Authenticated user whose ID/version should be represented.
  * @param kind - Token kind enforced by the verifier.
@@ -125,6 +128,8 @@ export function generateAccessToken(user: ExtendedUser): JWTtoken {
 export function generateRefreshToken(user: ExtendedUser): JWTtoken {
   return jwt.sign(buildTokenPayload(user, 'refresh'), getRefreshTokenSecret(), {
     expiresIn: REFRESH_TOKEN_EXPIRES_IN,
+    // Same-second refresh rotations need unique token strings for DB hashes.
+    jwtid: randomUUID(),
   })
 }
 

--- a/server/lib/JWT.ts
+++ b/server/lib/JWT.ts
@@ -1,5 +1,9 @@
 import type { CookieOptions } from 'express'
-import jwt, { type JwtPayload, TokenExpiredError } from 'jsonwebtoken'
+import jwt, {
+  JsonWebTokenError,
+  type JwtPayload,
+  TokenExpiredError,
+} from 'jsonwebtoken'
 
 import type { User } from '../../generated/prisma/client'
 
@@ -7,6 +11,13 @@ export const ACCESS_TOKEN_COOKIE_NAME = 'token'
 export const REFRESH_TOKEN_COOKIE_NAME = 'refreshToken'
 export const ACCESS_TOKEN_EXPIRES_IN = '1h'
 export const REFRESH_TOKEN_EXPIRES_IN = '7d'
+
+type TokenKind = 'access' | 'refresh'
+export type AuthTokenPayload = JwtPayload & {
+  kind: TokenKind
+  sessionVersion: number
+  sub: string
+}
 
 /**
  * Extended User type that represents the user returned from Prisma with extensions.
@@ -20,8 +31,8 @@ type ExtendedUser = Omit<User, 'createdAt' | 'updatedAt'> & {
 /**
  * Returns the secret used to sign refresh tokens.
  *
- * Called when issuing or verifying refresh cookies; falls back to the access
- * token secret so existing environments keep working until configured.
+ * Called when issuing or verifying refresh cookies; token-kind validation keeps
+ * refresh cookies from being accepted by the access-token verifier.
  *
  * @returns Refresh-token signing secret.
  * @example getRefreshTokenSecret()
@@ -34,6 +45,55 @@ const getRefreshTokenSecret = (): string => {
 }
 
 /**
+ * Builds the minimal JWT payload shared by access and refresh tokens.
+ *
+ * Called before signing so password hashes and other user fields never leave
+ * the server in a readable JWT body.
+ *
+ * @param user - Authenticated user whose ID/version should be represented.
+ * @param kind - Token kind enforced by the verifier.
+ * @returns Minimal token claims safe to store in HTTP-only cookies.
+ * @example buildTokenPayload(user, 'access')
+ */
+const buildTokenPayload = (
+  user: ExtendedUser,
+  kind: TokenKind,
+): Omit<AuthTokenPayload, keyof JwtPayload> => {
+  return {
+    kind,
+    sessionVersion: user.sessionVersion,
+    sub: String(user.id),
+  }
+}
+
+/**
+ * Verifies that a decoded JWT has the expected token kind.
+ *
+ * Called by access and refresh verifiers so refresh tokens cannot be replayed
+ * as access tokens even if environments share a secret.
+ *
+ * @param payload - Decoded JWT payload from `jsonwebtoken`.
+ * @param kind - Expected token kind for the current verifier.
+ * @returns Payload narrowed to the auth-token shape.
+ * @example assertTokenKind(payload, 'refresh')
+ */
+const assertTokenKind = (
+  payload: string | JwtPayload,
+  kind: TokenKind,
+): AuthTokenPayload => {
+  if (
+    typeof payload === 'string' ||
+    payload.kind !== kind ||
+    typeof payload.sub !== 'string' ||
+    typeof payload.sessionVersion !== 'number'
+  ) {
+    throw new JsonWebTokenError(`Invalid ${kind} token`)
+  }
+
+  return payload as AuthTokenPayload
+}
+
+/**
  * Generate the short-lived access token stored in the `token` cookie.
  *
  * Called by login, signup, and refresh rotation after a user is authenticated.
@@ -43,9 +103,13 @@ const getRefreshTokenSecret = (): string => {
  * @example generateAccessToken(user)
  */
 export function generateAccessToken(user: ExtendedUser): JWTtoken {
-  return jwt.sign(user, process.env.ACCESS_TOKEN_SECRET as string, {
-    expiresIn: ACCESS_TOKEN_EXPIRES_IN,
-  })
+  return jwt.sign(
+    buildTokenPayload(user, 'access'),
+    process.env.ACCESS_TOKEN_SECRET as string,
+    {
+      expiresIn: ACCESS_TOKEN_EXPIRES_IN,
+    },
+  )
 }
 
 /**
@@ -59,7 +123,7 @@ export function generateAccessToken(user: ExtendedUser): JWTtoken {
  * @example generateRefreshToken(user)
  */
 export function generateRefreshToken(user: ExtendedUser): JWTtoken {
-  return jwt.sign(user, getRefreshTokenSecret(), {
+  return jwt.sign(buildTokenPayload(user, 'refresh'), getRefreshTokenSecret(), {
     expiresIn: REFRESH_TOKEN_EXPIRES_IN,
   })
 }
@@ -76,12 +140,12 @@ export function getTokenExpiration(token: string): Date {
 }
 
 // Verify Access Token
-export function verifyAccessToken(token: string): JwtPayload {
+export function verifyAccessToken(token: string): AuthTokenPayload {
   try {
-    return jwt.verify(
-      token,
-      process.env.ACCESS_TOKEN_SECRET as string,
-    ) as JwtPayload
+    return assertTokenKind(
+      jwt.verify(token, process.env.ACCESS_TOKEN_SECRET as string),
+      'access',
+    )
   } catch (error) {
     // Explicitly handle expiration errors
     if (error instanceof TokenExpiredError) {
@@ -102,8 +166,8 @@ export function verifyAccessToken(token: string): JwtPayload {
  * @returns Verified JWT payload.
  * @example verifyRefreshToken(refreshToken)
  */
-export function verifyRefreshToken(token: string): JwtPayload {
-  return jwt.verify(token, getRefreshTokenSecret()) as JwtPayload
+export function verifyRefreshToken(token: string): AuthTokenPayload {
+  return assertTokenKind(jwt.verify(token, getRefreshTokenSecret()), 'refresh')
 }
 
 export function deleteJWTattribute(payload: JwtPayload) {
@@ -142,5 +206,8 @@ export function getCookieOptions(token: string): CookieOptions {
  * @example getRefreshCookieOptions(refreshToken)
  */
 export function getRefreshCookieOptions(token: string): CookieOptions {
-  return getCookieOptions(token)
+  return {
+    ...getCookieOptions(token),
+    sameSite: 'strict',
+  }
 }

--- a/server/lib/authSession.ts
+++ b/server/lib/authSession.ts
@@ -1,0 +1,338 @@
+import { createHash } from 'node:crypto'
+
+import type { Request, Response } from 'express'
+import {
+  JsonWebTokenError,
+  TokenExpiredError,
+  type JwtPayload,
+} from 'jsonwebtoken'
+
+import { prisma } from '../prisma'
+
+import {
+  ACCESS_TOKEN_COOKIE_NAME,
+  REFRESH_TOKEN_COOKIE_NAME,
+  generateAccessToken,
+  generateRefreshToken,
+  getCookieOptions,
+  getRefreshCookieOptions,
+  getTokenExpiration,
+  verifyAccessToken,
+  verifyRefreshToken,
+} from './JWT'
+import Logger from './Logger'
+
+export type AuthenticatedSessionUser = AuthenticatedUser
+
+type AuthSessionResult =
+  | { ok: true; user: AuthenticatedSessionUser }
+  | { ok: false; status: 401 | 500; message: string }
+
+const SESSION_USER_SELECT = {
+  id: true,
+  name: true,
+  password: true,
+  createdAt: true,
+  updatedAt: true,
+  useLegacyHoverColors: true,
+} as const
+
+/**
+ * Hashes a refresh token before it is stored or looked up.
+ *
+ * Called by refresh-token persistence so raw bearer credentials never live in
+ * the database.
+ *
+ * @param token - Raw refresh token cookie value.
+ * @returns SHA-256 hex digest of the token.
+ * @example hashRefreshToken(refreshToken)
+ */
+const hashRefreshToken = (token: string): string => {
+  return createHash('sha256').update(token).digest('hex')
+}
+
+/**
+ * Checks whether an error came from JWT verification.
+ *
+ * Called before deciding whether a failed auth attempt can try refresh-token
+ * rotation or must be treated as a server error.
+ *
+ * @param error - Unknown error thrown by `jsonwebtoken`.
+ * @returns True for expired or malformed JWT errors.
+ * @example isJwtVerificationError(error)
+ */
+const isJwtVerificationError = (error: unknown): boolean => {
+  return (
+    error instanceof TokenExpiredError || error instanceof JsonWebTokenError
+  )
+}
+
+/**
+ * Extracts the user identity fields from a JWT payload.
+ *
+ * Called before querying Prisma, so malformed payloads are rejected as
+ * unauthenticated requests.
+ *
+ * @param payload - Verified JWT payload.
+ * @returns Minimal identity tuple, or null when the payload is invalid.
+ * @example getTokenIdentity(payload)
+ */
+const getTokenIdentity = (
+  payload: JwtPayload,
+): { id: number; password: string } | null => {
+  if (typeof payload.id !== 'number') return null
+  if (typeof payload.password !== 'string') return null
+
+  return { id: payload.id, password: payload.password }
+}
+
+/**
+ * Finds the current user represented by a verified token payload.
+ *
+ * Called by access and refresh flows to reject stale sessions after password
+ * changes or account removal.
+ *
+ * @param payload - Verified access or refresh JWT payload.
+ * @returns Current user if the token still maps to a valid account.
+ * @example await findUserForTokenPayload(decoded)
+ */
+const findUserForTokenPayload = async (
+  payload: JwtPayload,
+): Promise<AuthenticatedSessionUser | null> => {
+  const identity = getTokenIdentity(payload)
+  if (!identity) return null
+
+  return prisma.user.findFirst({
+    select: SESSION_USER_SELECT,
+    where: {
+      id: identity.id,
+      password: identity.password,
+    },
+  })
+}
+
+/**
+ * Expires both authentication cookies.
+ *
+ * Called by logout and every invalid-token response so clients stop replaying
+ * rejected credentials.
+ *
+ * @param res - Express response used to update cookies.
+ * @returns Nothing; cookies are expired on the response.
+ * @example clearAuthCookies(res)
+ */
+export const clearAuthCookies = (res: Response): void => {
+  res.cookie(ACCESS_TOKEN_COOKIE_NAME, '', { expires: new Date() })
+  res.cookie(REFRESH_TOKEN_COOKIE_NAME, '', { expires: new Date() })
+}
+
+/**
+ * Persists a freshly generated refresh token.
+ *
+ * Called by login/signup and refresh rotation before cookies are returned.
+ *
+ * @param userId - User that owns the refresh token.
+ * @param refreshToken - Raw refresh token to hash and store.
+ * @returns Nothing after the token row is created.
+ * @example await storeRefreshToken(1, refreshToken)
+ */
+const storeRefreshToken = async (
+  userId: number,
+  refreshToken: JWTtoken,
+): Promise<void> => {
+  await prisma.refreshToken.create({
+    data: {
+      tokenHash: hashRefreshToken(refreshToken),
+      userId,
+      expiresAt: getTokenExpiration(refreshToken),
+    },
+  })
+}
+
+/**
+ * Revokes a refresh token if it exists.
+ *
+ * Called by logout and rotation to make replay of an old refresh cookie fail.
+ *
+ * @param refreshToken - Raw refresh token cookie value.
+ * @returns Nothing after matching active token rows are revoked.
+ * @example await revokeRefreshToken(refreshToken)
+ */
+export const revokeRefreshToken = async (
+  refreshToken: JWTtoken | undefined,
+): Promise<void> => {
+  if (!refreshToken) return
+
+  await prisma.refreshToken.updateMany({
+    where: {
+      tokenHash: hashRefreshToken(refreshToken),
+      revokedAt: null,
+    },
+    data: { revokedAt: new Date() },
+  })
+}
+
+/**
+ * Issues a new access/refresh cookie pair.
+ *
+ * Called by login/signup and after profile password changes so the browser has
+ * current short-lived access credentials plus a persisted refresh credential.
+ *
+ * @param res - Express response used to set cookies.
+ * @param user - Authenticated user used to sign both tokens.
+ * @returns Nothing after cookies and refresh-token storage are updated.
+ * @example await issueAuthCookies(res, user)
+ */
+export const issueAuthCookies = async (
+  res: Response,
+  user: AuthenticatedSessionUser,
+): Promise<void> => {
+  const accessToken = generateAccessToken(user)
+  const refreshToken = generateRefreshToken(user)
+
+  await storeRefreshToken(user.id, refreshToken)
+  res.cookie(
+    ACCESS_TOKEN_COOKIE_NAME,
+    accessToken,
+    getCookieOptions(accessToken),
+  )
+  res.cookie(
+    REFRESH_TOKEN_COOKIE_NAME,
+    refreshToken,
+    getRefreshCookieOptions(refreshToken),
+  )
+}
+
+/**
+ * Rotates a valid refresh token and returns the authenticated user.
+ *
+ * Called after an access token expires, replacing both cookies and revoking the
+ * consumed refresh token.
+ *
+ * @param res - Express response used to set replacement cookies.
+ * @param refreshToken - Raw refresh token cookie value.
+ * @returns Current user when refresh succeeds, otherwise null.
+ * @example await rotateRefreshSession(res, refreshToken)
+ */
+const rotateRefreshSession = async (
+  res: Response,
+  refreshToken: JWTtoken | undefined,
+): Promise<AuthenticatedSessionUser | null> => {
+  if (!refreshToken) return null
+
+  const decoded = verifyRefreshToken(refreshToken)
+  const tokenHash = hashRefreshToken(refreshToken)
+  const storedToken = await prisma.refreshToken.findFirst({
+    where: {
+      tokenHash,
+      revokedAt: null,
+      expiresAt: { gt: new Date() },
+    },
+  })
+
+  if (!storedToken) return null
+
+  const user = await findUserForTokenPayload(decoded)
+  if (!user) {
+    await revokeRefreshToken(refreshToken)
+    return null
+  }
+
+  const accessToken = generateAccessToken(user)
+  const nextRefreshToken = generateRefreshToken(user)
+
+  // Rotation is atomic so the old refresh token cannot remain active.
+  await prisma.$transaction([
+    prisma.refreshToken.updateMany({
+      where: { tokenHash, revokedAt: null },
+      data: { revokedAt: new Date() },
+    }),
+    prisma.refreshToken.create({
+      data: {
+        tokenHash: hashRefreshToken(nextRefreshToken),
+        userId: user.id,
+        expiresAt: getTokenExpiration(nextRefreshToken),
+      },
+    }),
+  ])
+
+  res.cookie(
+    ACCESS_TOKEN_COOKIE_NAME,
+    accessToken,
+    getCookieOptions(accessToken),
+  )
+  res.cookie(
+    REFRESH_TOKEN_COOKIE_NAME,
+    nextRefreshToken,
+    getRefreshCookieOptions(nextRefreshToken),
+  )
+
+  return user
+}
+
+/**
+ * Authenticates a request using access cookies with refresh fallback.
+ *
+ * Called by protected route middleware and account endpoints. A valid access
+ * token returns immediately; an expired/missing access token can be recovered by
+ * a valid DB-backed refresh token.
+ *
+ * @param req - Express request containing auth cookies.
+ * @param res - Express response used when refresh rotation sets cookies.
+ * @returns Authenticated user or a response-ready failure description.
+ * @example await authenticateRequestSession(req, res)
+ */
+export const authenticateRequestSession = async (
+  req: Request,
+  res: Response,
+): Promise<AuthSessionResult> => {
+  const accessToken = req.cookies[ACCESS_TOKEN_COOKIE_NAME] as
+    | JWTtoken
+    | undefined
+  const refreshToken = req.cookies[REFRESH_TOKEN_COOKIE_NAME] as
+    | JWTtoken
+    | undefined
+
+  if (accessToken) {
+    try {
+      const user = await findUserForTokenPayload(verifyAccessToken(accessToken))
+
+      if (user) return { ok: true, user }
+
+      Logger.info('Stale access token rejected')
+      clearAuthCookies(res)
+      return { ok: false, status: 401, message: 'Invalid or expired token' }
+    } catch (error) {
+      if (!(error instanceof TokenExpiredError)) {
+        if (isJwtVerificationError(error)) {
+          clearAuthCookies(res)
+          return { ok: false, status: 401, message: 'Invalid or expired token' }
+        }
+
+        Logger.error(error)
+        return { ok: false, status: 500, message: 'Authentication failed' }
+      }
+    }
+  }
+
+  try {
+    const refreshedUser = await rotateRefreshSession(res, refreshToken)
+
+    if (refreshedUser) return { ok: true, user: refreshedUser }
+  } catch (error) {
+    if (!isJwtVerificationError(error)) {
+      Logger.error(error)
+      return { ok: false, status: 500, message: 'Authentication failed' }
+    }
+  }
+
+  clearAuthCookies(res)
+  return {
+    ok: false,
+    status: 401,
+    message:
+      accessToken || refreshToken
+        ? 'Invalid or expired token'
+        : 'No token found',
+  }
+}

--- a/server/lib/authSession.ts
+++ b/server/lib/authSession.ts
@@ -1,16 +1,13 @@
 import { createHash } from 'node:crypto'
 
 import type { Request, Response } from 'express'
-import {
-  JsonWebTokenError,
-  TokenExpiredError,
-  type JwtPayload,
-} from 'jsonwebtoken'
+import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 
 import { prisma } from '../prisma'
 
 import {
   ACCESS_TOKEN_COOKIE_NAME,
+  type AuthTokenPayload,
   REFRESH_TOKEN_COOKIE_NAME,
   generateAccessToken,
   generateRefreshToken,
@@ -32,6 +29,7 @@ const SESSION_USER_SELECT = {
   id: true,
   name: true,
   password: true,
+  sessionVersion: true,
   createdAt: true,
   updatedAt: true,
   useLegacyHoverColors: true,
@@ -78,12 +76,12 @@ const isJwtVerificationError = (error: unknown): boolean => {
  * @example getTokenIdentity(payload)
  */
 const getTokenIdentity = (
-  payload: JwtPayload,
-): { id: number; password: string } | null => {
-  if (typeof payload.id !== 'number') return null
-  if (typeof payload.password !== 'string') return null
+  payload: AuthTokenPayload,
+): { id: number; sessionVersion: number } | null => {
+  const id = Number(payload.sub)
+  if (!Number.isInteger(id)) return null
 
-  return { id: payload.id, password: payload.password }
+  return { id, sessionVersion: payload.sessionVersion }
 }
 
 /**
@@ -97,7 +95,7 @@ const getTokenIdentity = (
  * @example await findUserForTokenPayload(decoded)
  */
 const findUserForTokenPayload = async (
-  payload: JwtPayload,
+  payload: AuthTokenPayload,
 ): Promise<AuthenticatedSessionUser | null> => {
   const identity = getTokenIdentity(payload)
   if (!identity) return null
@@ -106,7 +104,7 @@ const findUserForTokenPayload = async (
     select: SESSION_USER_SELECT,
     where: {
       id: identity.id,
-      password: identity.password,
+      sessionVersion: identity.sessionVersion,
     },
   })
 }
@@ -222,16 +220,6 @@ const rotateRefreshSession = async (
 
   const decoded = verifyRefreshToken(refreshToken)
   const tokenHash = hashRefreshToken(refreshToken)
-  const storedToken = await prisma.refreshToken.findFirst({
-    where: {
-      tokenHash,
-      revokedAt: null,
-      expiresAt: { gt: new Date() },
-    },
-  })
-
-  if (!storedToken) return null
-
   const user = await findUserForTokenPayload(decoded)
   if (!user) {
     await revokeRefreshToken(refreshToken)
@@ -241,20 +229,27 @@ const rotateRefreshSession = async (
   const accessToken = generateAccessToken(user)
   const nextRefreshToken = generateRefreshToken(user)
 
-  // Rotation is atomic so the old refresh token cannot remain active.
-  await prisma.$transaction([
-    prisma.refreshToken.updateMany({
-      where: { tokenHash, revokedAt: null },
+  // Rotation is atomic and single-use; replays cannot mint a successor token.
+  const rotated = await prisma.$transaction(async (tx) => {
+    const { count } = await tx.refreshToken.updateMany({
+      where: { tokenHash, revokedAt: null, expiresAt: { gt: new Date() } },
       data: { revokedAt: new Date() },
-    }),
-    prisma.refreshToken.create({
+    })
+
+    if (count !== 1) return false
+
+    await tx.refreshToken.create({
       data: {
         tokenHash: hashRefreshToken(nextRefreshToken),
         userId: user.id,
         expiresAt: getTokenExpiration(nextRefreshToken),
       },
-    }),
-  ])
+    })
+
+    return true
+  })
+
+  if (!rotated) return null
 
   res.cookie(
     ACCESS_TOKEN_COOKIE_NAME,

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -69,7 +69,7 @@ router.delete(
       const authorId = req.authenticatedUser?.id
 
       if (!authorId) {
-        res.status(401).json({ message: 'No token found' })
+        res.status(401).json({ error: 'No token found' })
         return
       }
 
@@ -77,19 +77,19 @@ router.delete(
 
       // Missing and forbidden are separated so clients can show the right state.
       if (ownership === 'missing') {
-        res.status(404).json({ message: 'Post not found' })
+        res.status(404).json({ error: 'Post not found' })
         return
       }
 
       if (ownership === 'forbidden') {
-        res.status(403).json({ message: 'Forbidden' })
+        res.status(403).json({ error: 'Forbidden' })
         return
       }
 
       await prisma.post.delete({
         where: { id: postId },
       })
-      res.status(200).json({ message: 'Delete Successful!' })
+      res.status(204).send()
     } catch (error: unknown) {
       if (error instanceof Error) {
         Logger.error(error)
@@ -198,7 +198,7 @@ router.post(
       const authorId = req.authenticatedUser?.id
 
       if (!authorId) {
-        res.status(401).json({ message: 'No token found' })
+        res.status(401).json({ error: 'No token found' })
         return
       }
 
@@ -206,12 +206,12 @@ router.post(
 
       // Only the post owner can update title/body.
       if (ownership === 'missing') {
-        res.status(404).json({ message: 'Post not found' })
+        res.status(404).json({ error: 'Post not found' })
         return
       }
 
       if (ownership === 'forbidden') {
-        res.status(403).json({ message: 'Forbidden' })
+        res.status(403).json({ error: 'Forbidden' })
         return
       }
 

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -14,6 +14,32 @@ import { prisma } from '../prisma'
 
 const router: Router = express.Router()
 
+/**
+ * Checks whether the authenticated user owns a post before mutation.
+ *
+ * Called by update/delete handlers so logged-in users cannot alter another
+ * author's content.
+ *
+ * @param postId - Post ID from the route or request body.
+ * @param authorId - Authenticated user ID from the session cookie.
+ * @returns Ownership status for response mapping.
+ * @example await getPostOwnershipStatus(1, 1)
+ */
+const getPostOwnershipStatus = async (
+  postId: number,
+  authorId: number,
+): Promise<'allowed' | 'forbidden' | 'missing'> => {
+  const post = await prisma.post.findUnique({
+    select: { authorId: true },
+    where: { id: postId },
+  })
+
+  if (!post) return 'missing'
+  if (post.authorId !== authorId) return 'forbidden'
+
+  return 'allowed'
+}
+
 router.get('/post/:id', async (req: Request, res: Response) => {
   try {
     const post = await prisma.post.findFirst({
@@ -39,8 +65,29 @@ router.delete(
   isAuthorized,
   async (req: Request, res: Response) => {
     try {
+      const postId = parseInt(String(req.params.id), 10)
+      const authorId = req.authenticatedUser?.id
+
+      if (!authorId) {
+        res.status(401).json({ message: 'No token found' })
+        return
+      }
+
+      const ownership = await getPostOwnershipStatus(postId, authorId)
+
+      // Missing and forbidden are separated so clients can show the right state.
+      if (ownership === 'missing') {
+        res.status(404).json({ message: 'Post not found' })
+        return
+      }
+
+      if (ownership === 'forbidden') {
+        res.status(403).json({ message: 'Forbidden' })
+        return
+      }
+
       await prisma.post.delete({
-        where: { id: parseInt(String(req.params.id), 10) },
+        where: { id: postId },
       })
       res.status(200).json({ message: 'Delete Successful!' })
     } catch (error: unknown) {
@@ -112,8 +159,16 @@ router.post(
   async (req: Request, res: Response) => {
     const { title, body } = req.body as CreatePostBody
     try {
+      const authorId = req.authenticatedUser?.id
+
+      if (!authorId) {
+        res.status(401).json({ error: 'No token found' })
+        return
+      }
+
       const post = await prisma.post.create({
         data: {
+          authorId,
           title: title,
           body: body,
         },
@@ -140,6 +195,26 @@ router.post(
   async (req: Request, res: Response, next: NextFunction) => {
     const body = req.body as UpdatePostBody
     try {
+      const authorId = req.authenticatedUser?.id
+
+      if (!authorId) {
+        res.status(401).json({ message: 'No token found' })
+        return
+      }
+
+      const ownership = await getPostOwnershipStatus(body.id, authorId)
+
+      // Only the post owner can update title/body.
+      if (ownership === 'missing') {
+        res.status(404).json({ message: 'Post not found' })
+        return
+      }
+
+      if (ownership === 'forbidden') {
+        res.status(403).json({ message: 'Forbidden' })
+        return
+      }
+
       await prisma.post.update({
         data: { title: body.title, body: body.body },
         where: { id: body.id },

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -157,15 +157,20 @@ router.post(
 )
 
 router.get('/stocklist', isAuthorized, async (req, res) => {
-  const userId = req.authenticatedUser?.id
+  try {
+    const userId = req.authenticatedUser?.id
 
-  if (!userId) {
-    res.status(401).json({ error: 'No token found' })
-    return
+    if (!userId) {
+      res.status(401).json({ error: 'No token found' })
+      return
+    }
+
+    const stockList = await prisma.stock.findMany({ where: { userId } })
+    res.status(200).json(stockList)
+  } catch (error) {
+    Logger.error(error)
+    res.status(500).json({ error: 'Internal Server Error' })
   }
-
-  const stockList = await prisma.stock.findMany({ where: { userId } })
-  res.status(200).json(stockList)
 })
 
 router.get('/stock/exists', isAuthorized, async (req, res, next) => {
@@ -199,7 +204,7 @@ router.delete('/stock/:id', isAuthorized, async (req, res) => {
     const userId = req.authenticatedUser?.id
 
     if (!userId) {
-      res.status(401).json({ message: 'No token found' })
+      res.status(401).json({ error: 'No token found' })
       return
     }
 
@@ -207,19 +212,19 @@ router.delete('/stock/:id', isAuthorized, async (req, res) => {
 
     // Delete is allowed only for the user who saved the page.
     if (ownership === 'missing') {
-      res.status(404).json({ message: 'Stock not found' })
+      res.status(404).json({ error: 'Stock not found' })
       return
     }
 
     if (ownership === 'forbidden') {
-      res.status(403).json({ message: 'Forbidden' })
+      res.status(403).json({ error: 'Forbidden' })
       return
     }
 
     await prisma.stock.delete({
       where: { id: stockId },
     })
-    res.status(200).json({ message: 'Delete Successful!' })
+    res.status(204).send()
   } catch (error: unknown) {
     if (error instanceof Error) {
       Logger.error(error)

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -63,18 +63,48 @@ const isValidStockUrl = (url: string): boolean => {
  * @param url - The normalized URL to check.
  * @returns Whether a matching stock row exists.
  * @example
- * await stockUrlExists('https://example.com') // => false
+ * await stockUrlExists('https://example.com', 1) // => false
  */
-const stockUrlExists = async (url: string): Promise<boolean> => {
+const stockUrlExists = async (
+  url: string,
+  userId: number,
+): Promise<boolean> => {
   const existingStock = await prisma.stock.findFirst({
-    where: { url },
+    where: { url, userId },
   })
 
   return Boolean(existingStock)
 }
 
+/**
+ * Checks whether the authenticated user owns a stock row before deletion.
+ *
+ * Called by the stock delete endpoint to prevent one user from consuming or
+ * removing another user's saved page.
+ *
+ * @param stockId - Stock ID from the route parameter.
+ * @param userId - Authenticated user ID from the session cookie.
+ * @returns Ownership status for response mapping.
+ * @example await getStockOwnershipStatus(1, 1)
+ */
+const getStockOwnershipStatus = async (
+  stockId: number,
+  userId: number,
+): Promise<'allowed' | 'forbidden' | 'missing'> => {
+  const stock = await prisma.stock.findUnique({
+    select: { userId: true },
+    where: { id: stockId },
+  })
+
+  if (!stock) return 'missing'
+  if (stock.userId !== userId) return 'forbidden'
+
+  return 'allowed'
+}
+
 router.post(
   '/push_stock',
+  isAuthorized,
   validateBody(pushStockBodySchema),
   async (req: Request, res: Response, next: NextFunction) => {
     const body = req.body as PushStockBody
@@ -82,6 +112,13 @@ router.post(
     const normalizedUrl = normalizeStockUrl(body.url)
 
     try {
+      const userId = req.authenticatedUser?.id
+
+      if (!userId) {
+        res.status(401).json({ error: 'No token found' })
+        return
+      }
+
       // Missing inputs are rejected before touching the database.
       if (!normalizedUrl) {
         res.status(400).json({ error: URL_REQUIRED_MESSAGE })
@@ -99,7 +136,7 @@ router.post(
       }
 
       // A duplicate page should look saved in the extension instead of creating a row.
-      if (await stockUrlExists(normalizedUrl)) {
+      if (await stockUrlExists(normalizedUrl, userId)) {
         res.status(409).json({ error: DUPLICATE_STOCK_MESSAGE })
         return
       }
@@ -108,6 +145,7 @@ router.post(
         data: {
           pageTitle,
           url: normalizedUrl,
+          userId,
         },
       })
       res.status(201).json(stock)
@@ -118,13 +156,26 @@ router.post(
   },
 )
 
-router.get('/stocklist', async (_req, res) => {
-  const stockList = await prisma.stock.findMany()
+router.get('/stocklist', isAuthorized, async (req, res) => {
+  const userId = req.authenticatedUser?.id
+
+  if (!userId) {
+    res.status(401).json({ error: 'No token found' })
+    return
+  }
+
+  const stockList = await prisma.stock.findMany({ where: { userId } })
   res.status(200).json(stockList)
 })
 
-router.get('/stock/exists', async (req, res, next) => {
+router.get('/stock/exists', isAuthorized, async (req, res, next) => {
   const normalizedUrl = normalizeStockUrl(req.query.url)
+  const userId = req.authenticatedUser?.id
+
+  if (!userId) {
+    res.status(401).json({ error: 'No token found' })
+    return
+  }
 
   try {
     // The popup needs a concrete URL to answer whether this page is already saved.
@@ -133,7 +184,9 @@ router.get('/stock/exists', async (req, res, next) => {
       return
     }
 
-    res.status(200).json({ exists: await stockUrlExists(normalizedUrl) })
+    res
+      .status(200)
+      .json({ exists: await stockUrlExists(normalizedUrl, userId) })
   } catch (error) {
     Logger.error(error)
     next(error)
@@ -142,8 +195,29 @@ router.get('/stock/exists', async (req, res, next) => {
 
 router.delete('/stock/:id', isAuthorized, async (req, res) => {
   try {
+    const stockId = parseInt(String(req.params.id), 10)
+    const userId = req.authenticatedUser?.id
+
+    if (!userId) {
+      res.status(401).json({ message: 'No token found' })
+      return
+    }
+
+    const ownership = await getStockOwnershipStatus(stockId, userId)
+
+    // Delete is allowed only for the user who saved the page.
+    if (ownership === 'missing') {
+      res.status(404).json({ message: 'Stock not found' })
+      return
+    }
+
+    if (ownership === 'forbidden') {
+      res.status(403).json({ message: 'Forbidden' })
+      return
+    }
+
     await prisma.stock.delete({
-      where: { id: parseInt(String(req.params.id), 10) },
+      where: { id: stockId },
     })
     res.status(200).json({ message: 'Delete Successful!' })
   } catch (error: unknown) {

--- a/server/routes/tweet.ts
+++ b/server/routes/tweet.ts
@@ -11,24 +11,63 @@ import { prisma } from '../prisma'
 
 const tweet: Router = express.Router()
 
-// TODO: add Tweet[] type to Response generic
-tweet.get('/', async (_req: Request, res: Response, next: NextFunction) => {
-  try {
-    const tweets = await prisma.tweet.findMany({
-      orderBy: {
-        createdAt: 'desc',
-      },
-    })
+/**
+ * Checks whether the authenticated user owns a tweet before deletion.
+ *
+ * Called by the tweet delete endpoint so one logged-in user cannot delete
+ * another user's tweet.
+ *
+ * @param tweetId - Tweet ID from the route parameter.
+ * @param userId - Authenticated user ID from the session cookie.
+ * @returns Ownership status for response mapping.
+ * @example await getTweetOwnershipStatus(1, 1)
+ */
+const getTweetOwnershipStatus = async (
+  tweetId: number,
+  userId: number,
+): Promise<'allowed' | 'forbidden' | 'missing'> => {
+  const existingTweet = await prisma.tweet.findUnique({
+    select: { userId: true },
+    where: { id: tweetId },
+  })
 
-    res.status(200).json(tweets)
-  } catch (error) {
-    next(error)
-  }
-})
+  if (!existingTweet) return 'missing'
+  if (existingTweet.userId !== userId) return 'forbidden'
+
+  return 'allowed'
+}
+
+// TODO: add Tweet[] type to Response generic
+tweet.get(
+  '/',
+  isAuthorized,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userId = req.authenticatedUser?.id
+
+      if (!userId) {
+        res.status(401).json({ error: 'No token found' })
+        return
+      }
+
+      const tweets = await prisma.tweet.findMany({
+        where: { userId },
+        orderBy: {
+          createdAt: 'desc',
+        },
+      })
+
+      res.status(200).json(tweets)
+    } catch (error) {
+      next(error)
+    }
+  },
+)
 
 // Paginated tweet list endpoint
 tweet.get(
   '/tweet_list',
+  isAuthorized,
   async (
     req: Request<
       _,
@@ -43,9 +82,16 @@ tweet.get(
     next: NextFunction,
   ) => {
     try {
+      const userId = req.authenticatedUser?.id
+
+      if (!userId) {
+        res.status(401).json({ error: 'No token found' })
+        return
+      }
+
       const page = parseInt(req.query.page, 10)
       const perPage = parseInt(req.query.perPage, 10)
-      const total = await prisma.tweet.count()
+      const total = await prisma.tweet.count({ where: { userId } })
 
       const offset = perPage * (page - 1)
       const options =
@@ -60,7 +106,10 @@ tweet.get(
               orderBy: { createdAt: 'desc' as const },
             } as const)
 
-      const tweetList = await prisma.tweet.findMany(options as any)
+      const tweetList = await prisma.tweet.findMany({
+        ...(options as any),
+        where: { userId },
+      })
       res.status(200).json({ tweetList, total })
     } catch (error) {
       next(error)
@@ -74,8 +123,15 @@ tweet.post(
   validateBody(createTweetBodySchema),
   async (req: Request, res: Response, next: NextFunction) => {
     try {
+      const userId = req.authenticatedUser?.id
+
+      if (!userId) {
+        res.status(401).json({ error: 'No token found' })
+        return
+      }
+
       const { text } = req.body as CreateTweetBody
-      const tweet = await prisma.tweet.create({ data: { text } })
+      const tweet = await prisma.tweet.create({ data: { text, userId } })
 
       res.status(201).json(tweet)
     } catch (error) {
@@ -86,9 +142,30 @@ tweet.post(
 
 tweet.delete(
   '/:id',
+  isAuthorized,
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       const id = parseInt(String(req.params.id), 10)
+      const userId = req.authenticatedUser?.id
+
+      if (!userId) {
+        res.status(401).json({ message: 'No token found' })
+        return
+      }
+
+      const ownership = await getTweetOwnershipStatus(id, userId)
+
+      // Only the tweet owner can remove a tweet.
+      if (ownership === 'missing') {
+        res.status(404).json({ message: 'Tweet not found' })
+        return
+      }
+
+      if (ownership === 'forbidden') {
+        res.status(403).json({ message: 'Forbidden' })
+        return
+      }
+
       await prisma.tweet.delete({ where: { id } })
 
       res.status(200).json({ message: 'Tweet deleted successfully' })

--- a/server/routes/tweet.ts
+++ b/server/routes/tweet.ts
@@ -2,6 +2,7 @@ import type { Request, Response, Router, NextFunction } from 'express'
 import express from 'express'
 
 import { isAuthorized } from '../auth'
+import Logger from '../lib/Logger'
 import {
   createTweetBodySchema,
   type CreateTweetBody,
@@ -59,6 +60,7 @@ tweet.get(
 
       res.status(200).json(tweets)
     } catch (error) {
+      Logger.error(error)
       next(error)
     }
   },
@@ -112,6 +114,7 @@ tweet.get(
       })
       res.status(200).json({ tweetList, total })
     } catch (error) {
+      Logger.error(error)
       next(error)
     }
   },
@@ -135,6 +138,7 @@ tweet.post(
 
       res.status(201).json(tweet)
     } catch (error) {
+      Logger.error(error)
       next(error)
     }
   },
@@ -149,7 +153,7 @@ tweet.delete(
       const userId = req.authenticatedUser?.id
 
       if (!userId) {
-        res.status(401).json({ message: 'No token found' })
+        res.status(401).json({ error: 'No token found' })
         return
       }
 
@@ -157,19 +161,20 @@ tweet.delete(
 
       // Only the tweet owner can remove a tweet.
       if (ownership === 'missing') {
-        res.status(404).json({ message: 'Tweet not found' })
+        res.status(404).json({ error: 'Tweet not found' })
         return
       }
 
       if (ownership === 'forbidden') {
-        res.status(403).json({ message: 'Forbidden' })
+        res.status(403).json({ error: 'Forbidden' })
         return
       }
 
       await prisma.tweet.delete({ where: { id } })
 
-      res.status(200).json({ message: 'Tweet deleted successfully' })
+      res.status(204).send()
     } catch (error) {
+      Logger.error(error)
       next(error)
     }
   },

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -2,13 +2,13 @@ import bcrypt from 'bcrypt'
 import type { Request, Response, Router, RequestHandler } from 'express'
 import express from 'express'
 import rateLimit from 'express-rate-limit'
-import { JsonWebTokenError, TokenExpiredError } from 'jsonwebtoken'
 
 import {
-  generateAccessToken,
-  getCookieOptions,
-  verifyAccessToken,
-} from '../lib/JWT'
+  authenticateRequestSession,
+  clearAuthCookies,
+  issueAuthCookies,
+  revokeRefreshToken,
+} from '../lib/authSession'
 import Logger from '../lib/Logger'
 import {
   hoverColorPreferenceBodySchema,
@@ -95,37 +95,6 @@ const sendAuthenticationFailure = (
   })
 }
 
-/**
- * Detects token verification failures thrown by `verifyAccessToken`.
- *
- * Called by PATCH handlers so invalid cookies return 401 instead of being
- * misclassified as server failures.
- *
- * @param error - Unknown error thrown while verifying a cookie token.
- * @returns Whether the error is an authentication failure.
- * @example isTokenVerificationError(new JsonWebTokenError('jwt malformed'))
- */
-const isTokenVerificationError = (error: unknown): boolean => {
-  return (
-    error instanceof TokenExpiredError || error instanceof JsonWebTokenError
-  )
-}
-
-/**
- * Sends the shared response for invalid or expired cookie tokens.
- *
- * Called by account-setting PATCH endpoints after token verification fails.
- *
- * @param res - Express response used to return the 401 payload.
- * @returns Nothing; the response is completed with status 401.
- * @example sendInvalidTokenResponse(res)
- */
-const sendInvalidTokenResponse = (res: Response<Res.Error>): void => {
-  // Expire the rejected session cookie so clients stop replaying it.
-  res.cookie('token', '', { expires: new Date() })
-  res.status(401).json({ error: 'Invalid or expired token' })
-}
-
 router.get(
   '/user_count',
   async (_req: Request, res: Response<Res.GetUserCount>) => {
@@ -147,8 +116,7 @@ const signupHandler: RequestHandler = async (req, res) => {
       },
     })
 
-    const token: JWTtoken = generateAccessToken(user)
-    res.cookie('token', token, getCookieOptions(token))
+    await issueAuthCookies(res, user)
     // Return user without password
     res.status(201).json({
       id: user.id,
@@ -193,7 +161,7 @@ router.post(
           password || 'missing-password',
           DUMMY_PASSWORD_HASH,
         )
-        Logger.warn('Invalid login payload')
+        Logger.info('Invalid login payload')
         res.status(400).json({
           error: 'Validation failed',
           code: 'VALIDATION_ERROR',
@@ -210,13 +178,12 @@ router.post(
 
       // Unknown users and wrong passwords must be indistinguishable to callers.
       if (!(user && isValidPassword)) {
-        Logger.warn('Failed login attempt')
+        Logger.info('Failed login attempt')
         sendAuthenticationFailure(res)
         return
       }
 
-      const token: JWTtoken = generateAccessToken(user)
-      res.cookie('token', token, getCookieOptions(token))
+      await issueAuthCookies(res, user)
       // Return user without password.
       res.status(200).json({
         id: user.id,
@@ -234,61 +201,44 @@ router.post(
   },
 )
 
-router.get('/logout', (_req: Request, res: Response<Res.Logout>) => {
-  res.cookie('token', '', { expires: new Date() })
+router.get('/logout', async (req: Request, res: Response<Res.Logout>) => {
+  await revokeRefreshToken(req.cookies.refreshToken as JWTtoken | undefined)
+  clearAuthCookies(res)
   res.status(200).json({ message: 'Logout Successful' })
 })
 
 const validateHandler: RequestHandler = async (req: Request, res: Response) => {
-  const token = req.cookies.token as JWTtoken
+  const session = await authenticateRequestSession(req, res)
 
-  if (!token) {
-    res.status(401).json({ valid: false, message: 'No token found' })
+  if (!session.ok) {
+    res.status(session.status).json({ valid: false, message: session.message })
     return
   }
 
-  try {
-    const decoded = verifyAccessToken(token)
-    const user = await prisma.user.findFirst({
-      select: {
-        id: true,
-        name: true,
-        createdAt: true,
-        updatedAt: true,
-      },
-      where: { id: decoded.id },
-    })
-
-    if (user) {
-      res.status(200).json({ valid: true, user })
-    } else {
-      res.cookie('token', '', { expires: new Date() })
-      res.status(401).json({ valid: false, message: 'User not found' })
-    }
-  } catch {
-    // Clear invalid token
-    res.cookie('token', '', { expires: new Date() })
-    res.status(401).json({ valid: false, message: 'Invalid or expired token' })
-  }
+  const {
+    password: _password,
+    useLegacyHoverColors: _useLegacy,
+    ...user
+  } = session.user
+  res.status(200).json({ valid: true, user })
 }
 
 router.get('/validate', validateHandler)
 
 router.get('/hover-color-preference', async (req: Request, res: Response) => {
-  const token = req.cookies.token as JWTtoken
+  const session = await authenticateRequestSession(req, res)
 
-  if (!token) {
-    res.status(401).json({ error: 'No token found' })
+  if (!session.ok) {
+    res.status(session.status).json({ error: session.message })
     return
   }
 
   try {
-    const decoded = verifyAccessToken(token)
     const user = await prisma.user.findFirst({
       select: {
         useLegacyHoverColors: true,
       },
-      where: { id: decoded.id },
+      where: { id: session.user.id },
     })
 
     if (user) {
@@ -306,19 +256,18 @@ router.patch(
   '/hover-color-preference',
   validateBody(hoverColorPreferenceBodySchema),
   async (req: Request, res: Response) => {
-    const token = req.cookies.token as JWTtoken
+    const session = await authenticateRequestSession(req, res)
 
-    if (!token) {
-      res.status(401).json({ error: 'No token found' })
+    if (!session.ok) {
+      res.status(session.status).json({ error: session.message })
       return
     }
 
     try {
-      const decoded = verifyAccessToken(token)
       const { useLegacyHoverColors } = req.body as HoverColorPreferenceBody
 
       const user = await prisma.user.update({
-        where: { id: decoded.id },
+        where: { id: session.user.id },
         data: { useLegacyHoverColors },
         select: {
           useLegacyHoverColors: true,
@@ -328,11 +277,6 @@ router.patch(
       res.status(200).json({ useLegacyHoverColors: user.useLegacyHoverColors })
     } catch (error) {
       Logger.error(error)
-      if (isTokenVerificationError(error)) {
-        sendInvalidTokenResponse(res)
-        return
-      }
-
       res.status(500).json({ error: 'Failed to update hover color preference' })
     }
   },
@@ -342,15 +286,14 @@ router.patch(
   '/profile',
   validateBody(updateProfileBodySchema),
   async (req: Request, res: Response) => {
-    const token = req.cookies.token as JWTtoken
+    const session = await authenticateRequestSession(req, res)
 
-    if (!token) {
-      res.status(401).json({ error: 'No token found' })
+    if (!session.ok) {
+      res.status(session.status).json({ error: session.message })
       return
     }
 
     try {
-      const decoded = verifyAccessToken(token)
       const { name, password } = req.body as UpdateProfileBody
 
       // Prepare update data
@@ -368,24 +311,30 @@ router.patch(
 
       // Update user in database
       const user = await prisma.user.update({
-        where: { id: decoded.id },
+        where: { id: session.user.id },
         data: updateData,
         select: {
           id: true,
           name: true,
+          password: true,
           createdAt: true,
           updatedAt: true,
+          useLegacyHoverColors: true,
         },
       })
 
-      res.status(200).json(user)
-    } catch (error) {
-      Logger.error(error)
-      if (isTokenVerificationError(error)) {
-        sendInvalidTokenResponse(res)
-        return
+      if (password) {
+        await issueAuthCookies(res, user)
       }
 
+      const {
+        password: _password,
+        useLegacyHoverColors: _useLegacy,
+        ...responseUser
+      } = user
+      res.status(200).json(responseUser)
+    } catch (error) {
+      Logger.error(error)
       res.status(500).json({ error: 'Failed to update profile' })
     }
   },

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -201,10 +201,16 @@ router.post(
   },
 )
 
-router.get('/logout', async (req: Request, res: Response<Res.Logout>) => {
-  await revokeRefreshToken(req.cookies.refreshToken as JWTtoken | undefined)
-  clearAuthCookies(res)
-  res.status(200).json({ message: 'Logout Successful' })
+router.post('/logout', async (req: Request, res: Response<Res.Logout>) => {
+  try {
+    await revokeRefreshToken(req.cookies.refreshToken as JWTtoken | undefined)
+  } catch (error) {
+    Logger.error(error)
+  } finally {
+    clearAuthCookies(res)
+  }
+
+  res.status(200).json({ success: true })
 })
 
 const validateHandler: RequestHandler = async (req: Request, res: Response) => {
@@ -218,6 +224,7 @@ const validateHandler: RequestHandler = async (req: Request, res: Response) => {
   const {
     password: _password,
     useLegacyHoverColors: _useLegacy,
+    sessionVersion: _sessionVersion,
     ...user
   } = session.user
   res.status(200).json({ valid: true, user })
@@ -297,7 +304,11 @@ router.patch(
       const { name, password } = req.body as UpdateProfileBody
 
       // Prepare update data
-      const updateData: { name?: string; password?: string } = {}
+      const updateData: {
+        name?: string
+        password?: string
+        sessionVersion?: { increment: number }
+      } = {}
 
       if (name) {
         updateData.name = name
@@ -307,6 +318,7 @@ router.patch(
         // Hash the new password
         const salt = await bcrypt.genSalt(10)
         updateData.password = await bcrypt.hash(password, salt)
+        updateData.sessionVersion = { increment: 1 }
       }
 
       // Update user in database
@@ -317,19 +329,21 @@ router.patch(
           id: true,
           name: true,
           password: true,
+          sessionVersion: true,
           createdAt: true,
           updatedAt: true,
           useLegacyHoverColors: true,
         },
       })
 
-      if (password) {
+      if (password || user.name !== session.user.name) {
         await issueAuthCookies(res, user)
       }
 
       const {
         password: _password,
         useLegacyHoverColors: _useLegacy,
+        sessionVersion: _sessionVersion,
         ...responseUser
       } = user
       res.status(200).json(responseUser)

--- a/src/components/Sidebar/LogoutLink.tsx
+++ b/src/components/Sidebar/LogoutLink.tsx
@@ -16,11 +16,9 @@ export async function handleLogout(
   e.preventDefault()
   const response = await dispatch(API.endpoints.logoutRequest.initiate())
 
-  if (isSuccess(response) && 'data' in response) {
+  if (isSuccess(response)) {
     dispatch(logout())
-    dispatch(
-      enqueSnackbar({ color: 'green', message: response.data?.message! }),
-    )
+    dispatch(enqueSnackbar({ color: 'green', message: 'Logout Successful' }))
     if (navigate) navigate('/')
   }
 }

--- a/src/pages/Dashboard/Create/StockList/handleClick.ts
+++ b/src/pages/Dashboard/Create/StockList/handleClick.ts
@@ -1,4 +1,3 @@
-import { selectUser } from '../../../../redux/adminSlice'
 import { API } from '../../../../redux/API'
 import { selectBody, updateBody } from '../../../../redux/draftSlice'
 import { dispatch, getRootState } from '../../../../redux/store'
@@ -8,10 +7,7 @@ export function handleClick(
   refetch: ReturnType<typeof API.endpoints.getStockList.useQuery>['refetch'],
 ) {
   return async () => {
-    const user = selectUser(getRootState())
-    await dispatch(
-      API.endpoints.deleteStock.initiate({ id: stock.id, author: user }),
-    )
+    await dispatch(API.endpoints.deleteStock.initiate({ id: stock.id }))
     // refetch stockList
     refetch()
     // Insert stock web page into the post body

--- a/src/pages/Dashboard/DashboardPostRow.tsx
+++ b/src/pages/Dashboard/DashboardPostRow.tsx
@@ -8,28 +8,20 @@ import PostLink from '../Index/PostList/PostRow/PostLink'
 import EditButtonGroup from './EditButtonGroup'
 
 interface Props {
-  author: User
   index: ArrayMapIndex
   post: Post
   refetch: UsePagenationResult['refetch']
 }
 
-const DashboardPostRow: React.FC<Props> = memo(
-  ({ author, index, post, refetch }) => {
-    return (
-      <li className="post-row">
-        <PostDate date={post.createdAt} />
-        <PostLink post={post} index={index} />
-        <EditButtonGroup
-          post={post}
-          author={author}
-          refetch={refetch}
-          index={index}
-        />
-      </li>
-    )
-  },
-)
+const DashboardPostRow: React.FC<Props> = memo(({ index, post, refetch }) => {
+  return (
+    <li className="post-row">
+      <PostDate date={post.createdAt} />
+      <PostLink post={post} index={index} />
+      <EditButtonGroup post={post} refetch={refetch} index={index} />
+    </li>
+  )
+})
 DashboardPostRow.displayName = 'DashboardPostRow'
 
 export default DashboardPostRow

--- a/src/pages/Dashboard/EditButtonGroup.tsx
+++ b/src/pages/Dashboard/EditButtonGroup.tsx
@@ -7,31 +7,28 @@ import type { UsePagenationResult } from '@/src/components/Pagination/usePaginat
 import { handleDelete } from './handler'
 
 interface Props {
-  author: User
   index: number
   post: Post
   refetch: UsePagenationResult['refetch']
 }
 
-const EditButtonGroup: React.FC<Props> = memo(
-  ({ author, index, post, refetch }) => {
-    return (
-      <div className="flex w-full justify-end space-x-2">
-        <Link to={`/dashboard/edit/${post.id}`}>
-          <Button variant="inverse">Edit</Button>
-        </Link>
-        <Button
-          onClick={handleDelete(post.id, author, refetch)}
-          variant="danger"
-          data-testid={`delete-btn-${index + 1}`}
-          className="h-[42px]"
-        >
-          Delete
-        </Button>
-      </div>
-    )
-  },
-)
+const EditButtonGroup: React.FC<Props> = memo(({ index, post, refetch }) => {
+  return (
+    <div className="flex w-full justify-end space-x-2">
+      <Link to={`/dashboard/edit/${post.id}`}>
+        <Button variant="inverse">Edit</Button>
+      </Link>
+      <Button
+        onClick={handleDelete(post.id, refetch)}
+        variant="danger"
+        data-testid={`delete-btn-${index + 1}`}
+        className="h-[42px]"
+      >
+        Delete
+      </Button>
+    </div>
+  )
+})
 EditButtonGroup.displayName = 'EditButtonGroup'
 
 export default EditButtonGroup

--- a/src/pages/Dashboard/handler.ts
+++ b/src/pages/Dashboard/handler.ts
@@ -1,6 +1,5 @@
 import type { UsePagenationResult } from '@/src/components/Pagination/usePagination'
 
-import type { AdminState } from '../../redux/adminSlice'
 import { API } from '../../redux/API'
 import isSuccess from '../../redux/helper/isSuccess'
 import { enqueSnackbar } from '../../redux/snackbarSlice'
@@ -8,13 +7,10 @@ import { dispatch } from '../../redux/store'
 
 export function handleDelete(
   id: Post['id'],
-  author: AdminState['author'],
   refetch: UsePagenationResult['refetch'],
 ) {
   return async function (): Promise<void> {
-    const res = await dispatch(
-      API.endpoints.deletePost.initiate({ id, author }),
-    )
+    const res = await dispatch(API.endpoints.deletePost.initiate({ id }))
 
     if (isSuccess(res) && 'data' in res) {
       dispatch(enqueSnackbar({ color: 'green', message: res.data?.message! }))

--- a/src/pages/Dashboard/handler.ts
+++ b/src/pages/Dashboard/handler.ts
@@ -12,8 +12,8 @@ export function handleDelete(
   return async function (): Promise<void> {
     const res = await dispatch(API.endpoints.deletePost.initiate({ id }))
 
-    if (isSuccess(res) && 'data' in res) {
-      dispatch(enqueSnackbar({ color: 'green', message: res.data?.message! }))
+    if (isSuccess(res)) {
+      dispatch(enqueSnackbar({ color: 'green', message: 'Delete Successful!' }))
       refetch()
     }
   }

--- a/src/pages/Dashboard/index.tsx
+++ b/src/pages/Dashboard/index.tsx
@@ -8,14 +8,10 @@ import PaginationButtonGroup from '@/src/components/Pagination/ButtonGroup'
 import usePagination from '@/src/components/Pagination/usePagination'
 import RTKQueryErrorMessages from '@/src/components/RTKQueryErrorMessages/RTKQueryErrorMessages'
 
-import { selectUser } from '../../redux/adminSlice'
-import { useAppSelector } from '../../redux/hooks'
-
 import DashboardPostRow from './DashboardPostRow'
 
 const Dashboard: React.FC = memo(() => {
   const { data, error, isLoading, page, refetch, totalPage } = usePagination(10)
-  const user = useAppSelector(selectUser)
 
   if (error) {
     return <RTKQueryErrorMessages error={error} />
@@ -39,7 +35,6 @@ const Dashboard: React.FC = memo(() => {
                 key={i}
                 post={post}
                 index={i}
-                author={user}
                 refetch={refetch}
               />
             )

--- a/src/redux/API.ts
+++ b/src/redux/API.ts
@@ -68,7 +68,7 @@ export const API = createApi({
       }),
     }),
 
-    deletePost: builder.mutation<Res.DeletePost, { id: Post['id'] }>({
+    deletePost: builder.mutation<void, { id: Post['id'] }>({
       invalidatesTags: (_result, _error, { id }) => [{ id, type: 'Posts' }],
       query: ({ id }) => ({
         method: 'DELETE',
@@ -76,7 +76,7 @@ export const API = createApi({
       }),
     }),
 
-    deleteStock: builder.mutation<Res.DeleteStock, { id: Stock['id'] }>({
+    deleteStock: builder.mutation<void, { id: Stock['id'] }>({
       query: ({ id }) => ({
         method: 'DELETE',
         url: `stock/${id}/`,
@@ -126,7 +126,7 @@ export const API = createApi({
 
     logoutRequest: builder.mutation<Res.Logout, void>({
       query: () => ({
-        method: 'GET',
+        method: 'POST',
         url: 'logout',
       }),
     }),
@@ -187,7 +187,7 @@ export const API = createApi({
       invalidatesTags: (result, _error) =>
         result ? [{ type: 'Tweets', id: 'LIST' }] : [],
     }),
-    deleteTweet: builder.mutation<{ message: string }, number>({
+    deleteTweet: builder.mutation<void, number>({
       query: (id: number) => ({
         method: 'DELETE',
         url: `tweet/${id}`,

--- a/src/redux/API.ts
+++ b/src/redux/API.ts
@@ -68,24 +68,16 @@ export const API = createApi({
       }),
     }),
 
-    deletePost: builder.mutation<
-      Res.DeletePost,
-      { id: Post['id']; author: User }
-    >({
+    deletePost: builder.mutation<Res.DeletePost, { id: Post['id'] }>({
       invalidatesTags: (_result, _error, { id }) => [{ id, type: 'Posts' }],
-      query: ({ id, author }) => ({
-        body: { author: author },
+      query: ({ id }) => ({
         method: 'DELETE',
         url: `post/${id}/`,
       }),
     }),
 
-    deleteStock: builder.mutation<
-      Res.DeleteStock,
-      { id: Stock['id']; author: User }
-    >({
-      query: ({ id, author }) => ({
-        body: { author: author },
+    deleteStock: builder.mutation<Res.DeleteStock, { id: Stock['id'] }>({
+      query: ({ id }) => ({
         method: 'DELETE',
         url: `stock/${id}/`,
       }),

--- a/validator/index.ts
+++ b/validator/index.ts
@@ -63,6 +63,7 @@ export const tweetSchema = z.object({
   text: z.string().min(1),
   createdAt: z.string(),
   updatedAt: z.string(),
+  userId: z.number(),
 })
 
 export type Tweet = z.infer<typeof tweetSchema>


### PR DESCRIPTION
## Summary
- add DB-backed refresh token rotation with 1h access cookies and 7d refresh cookies
- add ownership columns for posts, stocks, and tweets with migration backfill
- require auth for stock/tweet sensitive endpoints and enforce owner-only update/delete paths
- remove client-sent author payloads from delete requests

## Validation
- pnpm prisma format && pnpm prisma generate
- PRISMA_USER_CONSENT_FOR_DANGEROUS_AI_ACTION=yes pnpm db:reset
- pnpm typecheck
- pnpm lint
- pnpm test
- pnpm playwright e2e/admin/authentication.spec.ts e2e/admin/api-validation.spec.ts e2e/admin/authorization.spec.ts e2e/admin/post-crud.spec.ts e2e/admin/tweet-crud.spec.ts e2e/admin/tweet-pagination.spec.ts
- pnpm validate
- pnpm server:build

Closes #3731

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refresh-token sessions with access (~1h) and refresh (~7d) lifetimes and automatic rotation.
  * Resource ownership: posts, stocks, and tweets are created/returned per owning user; dashboard and UI actions use authenticated ownership.

* **Bug Fixes**
  * Endpoints enforce auth/ownership; logout revokes sessions and clears cookies; delete/create/update operations respect owner scoping.

* **Tests**
  * Expanded e2e/unit tests for expiry, rotation, logout, and authorization isolation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3764?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->