### PR TITLE
feat: standardize API v1 responses and errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,21 @@ These are stored in `.env` and evaluated at build time.
 - Uptime alerting: configure an external monitor such as UptimeRobot or Better Stack against `https://nsx.malloc.tokyo/api/health` with email/Slack/Discord alerts.
 - PM2 resource alerting: use `pm2 monit`, `pm2 install pm2-server-monit`, or pm2.io, and keep `max_memory_restart: 512M` in `ecosystem.config.js` as the restart guard.
 
+## API v1 Contract
+
+Legacy `/api/*` endpoints are kept for the current SPA. New integrations should use the versioned `/api/v1/*` endpoints, which always return a response envelope:
+
+```json
+{
+  "success": true,
+  "data": {},
+  "timestamp": "2026-05-27T00:00:00.000Z",
+  "requestId": "request_123"
+}
+```
+
+Errors use the same shape with `success: false`, `error`, and `code`, and never expose stack traces or raw internal exception messages. API metadata is available at `GET /api/v1/openapi.json`.
+
 ## Playwright
 
 I'm using [Playwright](https://playwright.dev/) for E2E testing.  

--- a/e2e/admin/api-validation.spec.ts
+++ b/e2e/admin/api-validation.spec.ts
@@ -214,6 +214,26 @@ test.describe('API request validation', () => {
       code: 'USERNAME_ALREADY_EXISTS',
     })
   })
+
+  test('rejects partially numeric post IDs before fetching posts', async ({
+    page,
+  }) => {
+    // Arrange
+    const partiallyNumericPostEndpoint = `${API_BASE_URL}/post/123abc`
+
+    // Act
+    const postResponse = await page
+      .context()
+      .request.get(partiallyNumericPostEndpoint)
+    const postBody = (await postResponse.json()) as Res.Error
+
+    // Assert
+    expect(postResponse.status()).toBe(400)
+    expect(postBody).toEqual({
+      code: 'VALIDATION_ERROR',
+      error: 'Post id must be a number',
+    })
+  })
 })
 
 test.afterAll(async () => {

--- a/e2e/api-v1.spec.ts
+++ b/e2e/api-v1.spec.ts
@@ -1,0 +1,116 @@
+import { expect, test } from '@playwright/test'
+
+test.describe('API v1 response contract', () => {
+  test('/api/v1/posts wraps paginated posts in a standard success envelope', async ({
+    request,
+  }) => {
+    // Arrange
+    const postsEndpoint = '/api/v1/posts?page=1&perPage=5'
+
+    // Act
+    const response = await request.get(postsEndpoint)
+    const body = await response.json()
+
+    // Assert
+    expect(response.status()).toBe(200)
+    expect(body).toMatchObject({
+      message: 'Posts retrieved',
+      meta: {
+        pagination: {
+          hasPrev: false,
+          page: 1,
+          perPage: 5,
+        },
+      },
+      success: true,
+    })
+    expect(Array.isArray(body.data)).toBe(true)
+    expect(typeof body.timestamp).toBe('string')
+    expect(typeof body.requestId).toBe('string')
+  })
+
+  test('/api/v1/posts/:id returns a standard not found error envelope', async ({
+    request,
+  }) => {
+    // Arrange
+    const missingPostEndpoint = '/api/v1/posts/999999999'
+
+    // Act
+    const response = await request.get(missingPostEndpoint)
+    const body = await response.json()
+
+    // Assert
+    expect(response.status()).toBe(404)
+    expect(body).toMatchObject({
+      code: 'NOT_FOUND',
+      error: 'Post not found',
+      success: false,
+    })
+    expect(body.stack).toBeUndefined()
+    expect(typeof body.requestId).toBe('string')
+  })
+
+  test('/api/v1/posts/:id rejects malformed IDs with a standard validation error', async ({
+    request,
+  }) => {
+    // Arrange
+    const malformedPostEndpoint = '/api/v1/posts/not-a-number'
+
+    // Act
+    const response = await request.get(malformedPostEndpoint)
+    const body = await response.json()
+
+    // Assert
+    expect(response.status()).toBe(400)
+    expect(body).toMatchObject({
+      code: 'VALIDATION_ERROR',
+      error: 'Route id must be a positive integer',
+      success: false,
+    })
+  })
+
+  test('/api/v1/users/count wraps user count in a standard success envelope', async ({
+    request,
+  }) => {
+    // Arrange
+    const userCountEndpoint = '/api/v1/users/count'
+
+    // Act
+    const response = await request.get(userCountEndpoint)
+    const body = await response.json()
+
+    // Assert
+    expect(response.status()).toBe(200)
+    expect(body).toMatchObject({
+      data: {
+        userCount: expect.any(Number),
+      },
+      message: 'User count retrieved',
+      success: true,
+    })
+  })
+
+  test('/api/v1/openapi.json exposes API documentation metadata', async ({
+    request,
+  }) => {
+    // Arrange
+    const openApiEndpoint = '/api/v1/openapi.json'
+
+    // Act
+    const response = await request.get(openApiEndpoint)
+    const body = await response.json()
+
+    // Assert
+    expect(response.status()).toBe(200)
+    expect(body).toMatchObject({
+      data: {
+        info: {
+          title: 'NSX API',
+          version: '1.0.0',
+        },
+        openapi: '3.0.0',
+      },
+      success: true,
+    })
+  })
+})

--- a/server/api.ts
+++ b/server/api.ts
@@ -8,9 +8,11 @@ import stockRoute from './routes/stock'
 import translateRoute from './routes/translate'
 import tweet from './routes/tweet'
 import userRoute from './routes/user'
+import v1Route from './routes/v1'
 
 const router: Router = express.Router()
 
+router.use(v1Route)
 router.use(healthRoute)
 // TODO: Refactor /tweet style
 router.use(postRoute)

--- a/server/index.ts
+++ b/server/index.ts
@@ -15,6 +15,7 @@ import helmet from 'helmet'
 
 import router from './api'
 import { Cron } from './cron'
+import { apiErrorHandler } from './lib/apiResponses'
 import Logger from './lib/Logger'
 import {
   initializeMetrics,
@@ -84,6 +85,7 @@ app.use(cookieParser())
 app.use(requestMonitoringMiddleware)
 app.use(compression())
 app.use('/api', router)
+app.use('/api', apiErrorHandler)
 /**
  DEV Server
  */

--- a/server/lib/apiErrors.ts
+++ b/server/lib/apiErrors.ts
@@ -1,0 +1,135 @@
+export type ApiErrorCode =
+  | 'AUTHENTICATION_ERROR'
+  | 'AUTHORIZATION_ERROR'
+  | 'CONFLICT'
+  | 'INTERNAL_ERROR'
+  | 'NOT_FOUND'
+  | 'VALIDATION_ERROR'
+
+type AppErrorOptions = {
+  code: ApiErrorCode
+  details?: unknown
+  isOperational?: boolean
+  message: string
+  statusCode: number
+}
+
+/**
+ * Describes an error that is safe for API middleware to map into JSON.
+ * @example throw new AppError({ message: 'Post not found', statusCode: 404, code: 'NOT_FOUND' })
+ */
+export class AppError extends Error {
+  public readonly code: ApiErrorCode
+  public readonly details?: unknown
+  public readonly isOperational: boolean
+  public readonly statusCode: number
+
+  public constructor({
+    code,
+    details,
+    isOperational = true,
+    message,
+    statusCode,
+  }: AppErrorOptions) {
+    super(message)
+    this.name = 'AppError'
+    this.code = code
+    this.details = details
+    this.isOperational = isOperational
+    this.statusCode = statusCode
+  }
+}
+
+/**
+ * Builds a 400 error for invalid API input.
+ * @param message - Safe client-facing validation message.
+ * @param details - Optional field-level validation metadata.
+ * @returns AppError with validation status and code.
+ * @example validationError('Invalid post id')
+ */
+export const validationError = (
+  message: string,
+  details?: unknown,
+): AppError => {
+  return new AppError({
+    code: 'VALIDATION_ERROR',
+    details,
+    message,
+    statusCode: 400,
+  })
+}
+
+/**
+ * Builds a 401 error for unauthenticated requests.
+ * @param message - Safe client-facing authentication message.
+ * @returns AppError with authentication status and code.
+ * @example authenticationError('Authentication required')
+ */
+export const authenticationError = (
+  message = 'Authentication required',
+): AppError => {
+  return new AppError({
+    code: 'AUTHENTICATION_ERROR',
+    message,
+    statusCode: 401,
+  })
+}
+
+/**
+ * Builds a 403 error for authenticated users lacking permission.
+ * @param message - Safe client-facing authorization message.
+ * @returns AppError with authorization status and code.
+ * @example authorizationError('Forbidden')
+ */
+export const authorizationError = (message = 'Forbidden'): AppError => {
+  return new AppError({
+    code: 'AUTHORIZATION_ERROR',
+    message,
+    statusCode: 403,
+  })
+}
+
+/**
+ * Builds a 404 error for missing API resources.
+ * @param resourceName - Resource label used in the response message.
+ * @returns AppError with not-found status and code.
+ * @example notFoundError('Post')
+ */
+export const notFoundError = (resourceName = 'Resource'): AppError => {
+  return new AppError({
+    code: 'NOT_FOUND',
+    message: `${resourceName} not found`,
+    statusCode: 404,
+  })
+}
+
+/**
+ * Builds a 409 error for duplicate or conflicting API writes.
+ * @param message - Safe client-facing conflict message.
+ * @returns AppError with conflict status and code.
+ * @example conflictError('Username already exists')
+ */
+export const conflictError = (message: string): AppError => {
+  return new AppError({
+    code: 'CONFLICT',
+    message,
+    statusCode: 409,
+  })
+}
+
+/**
+ * Converts unknown thrown values into a safe API error.
+ * @param error - Unknown value caught by Express error middleware.
+ * @returns Original AppError or a generic 500 wrapper.
+ * @example toAppError(new Error('boom'))
+ */
+export const toAppError = (error: unknown): AppError => {
+  if (error instanceof AppError) return error
+
+  return new AppError({
+    code: 'INTERNAL_ERROR',
+    isOperational: false,
+    message: 'Internal Server Error',
+    statusCode: 500,
+  })
+}

--- a/server/lib/apiResponses.ts
+++ b/server/lib/apiResponses.ts
@@ -1,0 +1,167 @@
+import type { ErrorRequestHandler, Response } from 'express'
+
+import type { AppError } from './apiErrors'
+import { toAppError } from './apiErrors'
+import Logger from './Logger'
+import { getCurrentRequestId } from './requestContext'
+import { captureException } from './sentry'
+
+type PaginationMeta = {
+  hasNext: boolean
+  hasPrev: boolean
+  page: number
+  perPage: number
+  total: number
+  totalPages: number
+}
+
+type ApiSuccessResponse<T> = {
+  data: T
+  message?: string
+  meta?: {
+    pagination?: PaginationMeta
+  }
+  requestId?: string
+  success: true
+  timestamp: string
+}
+
+type ApiErrorResponse = {
+  code: AppError['code']
+  details?: unknown
+  error: string
+  requestId?: string
+  success: false
+  timestamp: string
+}
+
+type SendSuccessOptions = {
+  message?: string
+  meta?: ApiSuccessResponse<unknown>['meta']
+  statusCode?: number
+}
+
+/**
+ * Creates the shared response envelope fields for API v1 responses.
+ * @returns Timestamp and request ID fields for response builders.
+ * @example createResponseBase()
+ */
+const createResponseBase = (): {
+  requestId?: string
+  timestamp: string
+} => {
+  const requestId = getCurrentRequestId()
+
+  return {
+    ...(requestId ? { requestId } : {}),
+    timestamp: new Date().toISOString(),
+  }
+}
+
+/**
+ * Sends a standardized successful API response.
+ * @param res - Express response object.
+ * @param data - Domain payload returned to the client.
+ * @param options - Optional status, message, and metadata.
+ * @returns Nothing; the response is completed.
+ * @example sendSuccess(res, { userCount: 1 })
+ */
+export const sendSuccess = <T>(
+  res: Response<ApiSuccessResponse<T>>,
+  data: T,
+  options: SendSuccessOptions = {},
+): void => {
+  const { message, meta, statusCode = 200 } = options
+
+  res.status(statusCode).json({
+    ...createResponseBase(),
+    data,
+    ...(message ? { message } : {}),
+    ...(meta ? { meta } : {}),
+    success: true,
+  })
+}
+
+/**
+ * Creates pagination metadata for list endpoints.
+ * @param page - Current one-based page number.
+ * @param perPage - Number of items requested per page.
+ * @param total - Total matching row count.
+ * @returns Stable pagination metadata for API v1 responses.
+ * @example createPaginationMeta(1, 10, 25)
+ */
+export const createPaginationMeta = (
+  page: number,
+  perPage: number,
+  total: number,
+): PaginationMeta => {
+  const totalPages = Math.ceil(total / perPage)
+
+  return {
+    hasNext: page < totalPages,
+    hasPrev: page > 1,
+    page,
+    perPage,
+    total,
+    totalPages,
+  }
+}
+
+/**
+ * Sends a standardized API error response.
+ * @param res - Express response object.
+ * @param error - AppError already mapped to a safe client response.
+ * @returns Nothing; the response is completed.
+ * @example sendApiError(res, notFoundError('Post'))
+ */
+export const sendApiError = (
+  res: Response<ApiErrorResponse>,
+  error: AppError,
+): void => {
+  res.status(error.statusCode).json({
+    ...createResponseBase(),
+    code: error.code,
+    ...(error.details ? { details: error.details } : {}),
+    error: error.message,
+    success: false,
+  })
+}
+
+/**
+ * Final Express API error middleware for standardized JSON failures.
+ * @param error - Unknown error passed by Express.
+ * @param req - Request that failed.
+ * @param res - Response used to return the standardized error.
+ * @param next - Express fallback used only when headers are already sent.
+ * @returns Nothing; sends JSON unless Express has already started the response.
+ * @example app.use('/api/v1', apiErrorHandler)
+ */
+export const apiErrorHandler: ErrorRequestHandler = (
+  error,
+  req,
+  res: Response<ApiErrorResponse>,
+  next,
+) => {
+  if (res.headersSent) {
+    next(error)
+    return
+  }
+
+  const appError = toAppError(error)
+  const logContext = {
+    error,
+    method: req.method,
+    path: req.path,
+    statusCode: appError.statusCode,
+  }
+
+  // Server errors are captured for operators; client errors are only logged.
+  if (appError.statusCode >= 500) {
+    Logger.error('API request failed', logContext)
+    captureException(error)
+  } else {
+    Logger.warn('API request rejected', logContext)
+  }
+
+  sendApiError(res, appError)
+}

--- a/server/routes/bluesky.ts
+++ b/server/routes/bluesky.ts
@@ -92,7 +92,6 @@ router.post(
 
       res.status(500).json({
         error: 'Failed to post to BlueSky',
-        details: error instanceof Error ? error.message : 'Unknown error',
       })
     }
   },
@@ -113,9 +112,9 @@ router.get('/bluesky/status', async (req, res) => {
           : null,
     })
   } catch (error) {
+    Logger.error('BlueSky status error', { error })
     res.status(500).json({
       error: 'Failed to check status',
-      details: error instanceof Error ? error.message : 'Unknown error',
     })
   }
 })

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -44,15 +44,17 @@ const getPostOwnershipStatus = async (
 
 router.get('/post/:id', async (req: Request, res: Response) => {
   try {
-    const postId = parseInt(String(req.params.id), 10)
+    const rawPostId = String(req.params.id)
 
-    if (!Number.isInteger(postId)) {
+    // Reject mixed values like "123abc" before Prisma receives an ID.
+    if (!/^[1-9]\d*$/.test(rawPostId)) {
       res.status(400).json({
         code: 'VALIDATION_ERROR',
         error: 'Post id must be a number',
       })
       return
     }
+    const postId = parseInt(rawPostId, 10)
 
     const post = await prisma.post.findFirst({
       where: { id: postId },

--- a/server/routes/post.ts
+++ b/server/routes/post.ts
@@ -14,6 +14,8 @@ import { prisma } from '../prisma'
 
 const router: Router = express.Router()
 
+const INTERNAL_SERVER_ERROR_RESPONSE = { error: 'Internal Server Error' }
+
 /**
  * Checks whether the authenticated user owns a post before mutation.
  *
@@ -42,20 +44,33 @@ const getPostOwnershipStatus = async (
 
 router.get('/post/:id', async (req: Request, res: Response) => {
   try {
+    const postId = parseInt(String(req.params.id), 10)
+
+    if (!Number.isInteger(postId)) {
+      res.status(400).json({
+        code: 'VALIDATION_ERROR',
+        error: 'Post id must be a number',
+      })
+      return
+    }
+
     const post = await prisma.post.findFirst({
-      where: { id: parseInt(String(req.params.id), 10) },
+      where: { id: postId },
     })
+
+    if (!post) {
+      res.status(404).json({ error: 'Post not found' })
+      return
+    }
 
     res.status(200).json(post)
   } catch (error: unknown) {
     if (error instanceof Error) {
       Logger.error(error)
-      res.status(500).json({ error: error.message })
+      res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
     } else {
       Logger.error(error)
-      res.status(500).json({
-        error: `something wrong: ${JSON.stringify(error)}`,
-      })
+      res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
     }
   }
 })
@@ -91,15 +106,8 @@ router.delete(
       })
       res.status(204).send()
     } catch (error: unknown) {
-      if (error instanceof Error) {
-        Logger.error(error)
-        res.status(500).json({ message: error.message })
-      } else {
-        Logger.error(error)
-        res
-          .status(500)
-          .json({ message: `someting wrong: ${JSON.stringify(error)}` })
-      }
+      Logger.error(error)
+      res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
     }
   },
 )
@@ -141,12 +149,10 @@ router.get(
     } catch (error: unknown) {
       if (error instanceof Error) {
         Logger.error(error)
-        res.status(500).json({ error: error.message })
+        res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
       } else {
         Logger.error(error)
-        res.status(500).json({
-          error: `something wrong: ${JSON.stringify(error)}`,
-        })
+        res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
       }
     }
   },
@@ -177,12 +183,10 @@ router.post(
     } catch (error: unknown) {
       if (error instanceof Error) {
         Logger.error(error)
-        res.status(500).json({ error: error.message })
+        res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
       } else {
         Logger.error(error)
-        res.status(500).json({
-          error: `something wrong: ${JSON.stringify(error)}`,
-        })
+        res.status(500).json(INTERNAL_SERVER_ERROR_RESPONSE)
       }
     }
   },

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -226,15 +226,8 @@ router.delete('/stock/:id', isAuthorized, async (req, res) => {
     })
     res.status(204).send()
   } catch (error: unknown) {
-    if (error instanceof Error) {
-      Logger.error(error)
-      res.status(500).json({ message: error.message })
-    } else {
-      Logger.error(error)
-      res
-        .status(500)
-        .json({ message: `someting wrong: ${JSON.stringify(error)}` })
-    }
+    Logger.error(error)
+    res.status(500).json({ error: 'Internal Server Error' })
   }
 })
 

--- a/server/routes/user.ts
+++ b/server/routes/user.ts
@@ -30,6 +30,7 @@ const AUTHENTICATION_FAILED_MESSAGE = 'Invalid credentials'
 const AUTHENTICATION_SERVICE_ERROR_CODE = 'AUTHENTICATION_SERVICE_ERROR'
 const AUTHENTICATION_SERVICE_ERROR_MESSAGE =
   'Authentication service temporarily unavailable'
+const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal Server Error'
 const USERNAME_ALREADY_EXISTS_CODE = 'USERNAME_ALREADY_EXISTS'
 const USERNAME_ALREADY_EXISTS_MESSAGE = 'Username already exists'
 const DUMMY_PASSWORD_HASH =
@@ -170,12 +171,10 @@ const signupHandler: RequestHandler = async (req, res) => {
 
     if (error instanceof Error) {
       Logger.error(error)
-      res.status(500).json({ error: error.message })
+      res.status(500).json({ error: INTERNAL_SERVER_ERROR_MESSAGE })
     } else {
       Logger.error(error)
-      res.status(500).json({
-        error: `something wrong: ${JSON.stringify(error)}`,
-      })
+      res.status(500).json({ error: INTERNAL_SERVER_ERROR_MESSAGE })
     }
   }
 }

--- a/server/routes/v1.ts
+++ b/server/routes/v1.ts
@@ -7,6 +7,7 @@ import {
   createPaginationMeta,
   sendSuccess,
 } from '../lib/apiResponses'
+import Logger from '../lib/Logger'
 import { prisma } from '../prisma'
 
 const router: Router = express.Router()
@@ -149,10 +150,21 @@ router.get('/v1/openapi.json', (_req: Request, res: Response) => {
   sendSuccess(res, openApiDocument)
 })
 
-router.get('/v1/users/count', async (_req: Request, res: Response) => {
-  const userCount = await prisma.user.count()
-  sendSuccess(res, { userCount }, { message: 'User count retrieved' })
-})
+router.get(
+  '/v1/users/count',
+  async (_req: Request, res: Response, next: NextFunction) => {
+    try {
+      const userCount = await prisma.user.count()
+      sendSuccess(res, { userCount }, { message: 'User count retrieved' })
+    } catch (error: unknown) {
+      Logger.error('API v1 user count route failed', {
+        error,
+        route: '/api/v1/users/count',
+      })
+      next(error)
+    }
+  },
+)
 
 router.get(
   '/v1/posts',
@@ -167,41 +179,63 @@ router.get(
       }
     >,
     res: Response,
+    next: NextFunction,
   ) => {
-    const page = parsePositiveInteger(req.query.page, DEFAULT_PAGE)
-    const perPage = parsePositiveInteger(
-      req.query.perPage,
-      DEFAULT_PER_PAGE,
-      MAX_PER_PAGE,
-    )
-    const total = await prisma.post.count()
-    const posts = await prisma.post.findMany({
-      orderBy: { id: 'desc' },
-      skip: perPage * (page - 1),
-      take: perPage,
-    })
+    try {
+      const page = parsePositiveInteger(req.query.page, DEFAULT_PAGE)
+      const perPage = parsePositiveInteger(
+        req.query.perPage,
+        DEFAULT_PER_PAGE,
+        MAX_PER_PAGE,
+      )
+      const total = await prisma.post.count()
+      const posts = await prisma.post.findMany({
+        orderBy: { id: 'desc' },
+        skip: perPage * (page - 1),
+        take: perPage,
+      })
 
-    sendSuccess(res, posts, {
-      message: 'Posts retrieved',
-      meta: {
-        pagination: createPaginationMeta(page, perPage, total),
-      },
-    })
+      sendSuccess(res, posts, {
+        message: 'Posts retrieved',
+        meta: {
+          pagination: createPaginationMeta(page, perPage, total),
+        },
+      })
+    } catch (error: unknown) {
+      Logger.error('API v1 posts route failed', {
+        error,
+        query: req.query,
+        route: '/api/v1/posts',
+      })
+      next(error)
+    }
   },
 )
 
-router.get('/v1/posts/:id', async (req: Request, res: Response) => {
-  const postId = parseRouteId(req.params.id)
-  const post = await prisma.post.findUnique({
-    where: { id: postId },
-  })
+router.get(
+  '/v1/posts/:id',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const postId = parseRouteId(req.params.id)
+      const post = await prisma.post.findUnique({
+        where: { id: postId },
+      })
 
-  if (!post) {
-    throw notFoundError('Post')
-  }
+      if (!post) {
+        throw notFoundError('Post')
+      }
 
-  sendSuccess(res, post, { message: 'Post retrieved' })
-})
+      sendSuccess(res, post, { message: 'Post retrieved' })
+    } catch (error: unknown) {
+      Logger.error('API v1 post route failed', {
+        error,
+        params: req.params,
+        route: '/api/v1/posts/:id',
+      })
+      next(error)
+    }
+  },
+)
 
 router.use('/v1', handleMissingV1Route)
 

--- a/server/routes/v1.ts
+++ b/server/routes/v1.ts
@@ -1,0 +1,210 @@
+import type { NextFunction, Request, Response, Router } from 'express'
+import express from 'express'
+
+import { validationError, notFoundError } from '../lib/apiErrors'
+import {
+  apiErrorHandler,
+  createPaginationMeta,
+  sendSuccess,
+} from '../lib/apiResponses'
+import { prisma } from '../prisma'
+
+const router: Router = express.Router()
+
+const DEFAULT_PAGE = 1
+const DEFAULT_PER_PAGE = 10
+const MAX_PER_PAGE = 100
+
+const openApiDocument = {
+  components: {
+    schemas: {
+      ApiError: {
+        properties: {
+          code: { example: 'NOT_FOUND', type: 'string' },
+          error: { example: 'Post not found', type: 'string' },
+          requestId: { type: 'string' },
+          success: { example: false, type: 'boolean' },
+          timestamp: { format: 'date-time', type: 'string' },
+        },
+        required: ['success', 'error', 'code', 'timestamp'],
+        type: 'object',
+      },
+      ApiSuccess: {
+        properties: {
+          data: { type: 'object' },
+          requestId: { type: 'string' },
+          success: { example: true, type: 'boolean' },
+          timestamp: { format: 'date-time', type: 'string' },
+        },
+        required: ['success', 'data', 'timestamp'],
+        type: 'object',
+      },
+    },
+  },
+  info: {
+    description: 'Versioned NSX API with standardized response envelopes.',
+    title: 'NSX API',
+    version: '1.0.0',
+  },
+  openapi: '3.0.0',
+  paths: {
+    '/api/v1/posts': {
+      get: {
+        responses: {
+          '200': { description: 'Paginated posts response' },
+          '400': { description: 'Invalid pagination query' },
+        },
+        summary: 'List posts',
+      },
+    },
+    '/api/v1/posts/{id}': {
+      get: {
+        responses: {
+          '200': { description: 'Post response' },
+          '400': { description: 'Invalid post ID' },
+          '404': { description: 'Post not found' },
+        },
+        summary: 'Get a post',
+      },
+    },
+    '/api/v1/users/count': {
+      get: {
+        responses: {
+          '200': { description: 'User count response' },
+        },
+        summary: 'Count users',
+      },
+    },
+  },
+  servers: [
+    { url: 'https://nsx.malloc.tokyo' },
+    { url: 'http://localhost:4000' },
+  ],
+}
+
+/**
+ * Parses a positive integer query value with a bounded fallback.
+ * @param value - Raw query value from Express.
+ * @param fallback - Number used when the query value is absent.
+ * @param maxValue - Optional maximum accepted value.
+ * @returns Positive integer ready for Prisma pagination.
+ * @example parsePositiveInteger('2', 1, 100) // => 2
+ */
+const parsePositiveInteger = (
+  value: unknown,
+  fallback: number,
+  maxValue?: number,
+): number => {
+  if (value === undefined) return fallback
+  if (typeof value !== 'string') throw validationError('Query must be a string')
+
+  const parsedValue = Number(value)
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 1) {
+    throw validationError('Query must be a positive integer')
+  }
+
+  if (maxValue && parsedValue > maxValue) {
+    throw validationError(`Query must be less than or equal to ${maxValue}`)
+  }
+
+  return parsedValue
+}
+
+/**
+ * Parses a route ID into a positive integer.
+ * @param value - Raw path parameter from Express.
+ * @returns Positive integer ID for Prisma lookups.
+ * @example parseRouteId('42') // => 42
+ */
+const parseRouteId = (value: unknown): number => {
+  if (typeof value !== 'string') throw validationError('Route id is required')
+
+  const parsedValue = Number(value)
+
+  if (!Number.isInteger(parsedValue) || parsedValue < 1) {
+    throw validationError('Route id must be a positive integer')
+  }
+
+  return parsedValue
+}
+
+/**
+ * Converts unmatched API v1 URLs into the standardized JSON 404 shape.
+ * @param _req - Express request that reached the v1 fallback.
+ * @param _res - Unused response; the error handler sends the JSON response.
+ * @param next - Express continuation receiving the not-found error.
+ * @returns Nothing; forwards a Route not found error.
+ * @example router.use('/v1', handleMissingV1Route)
+ */
+const handleMissingV1Route = (
+  _req: Request,
+  _res: Response,
+  next: NextFunction,
+): void => {
+  next(notFoundError('Route'))
+}
+
+router.get('/v1/openapi.json', (_req: Request, res: Response) => {
+  sendSuccess(res, openApiDocument)
+})
+
+router.get('/v1/users/count', async (_req: Request, res: Response) => {
+  const userCount = await prisma.user.count()
+  sendSuccess(res, { userCount }, { message: 'User count retrieved' })
+})
+
+router.get(
+  '/v1/posts',
+  async (
+    req: Request<
+      _,
+      _,
+      _,
+      {
+        page?: string
+        perPage?: string
+      }
+    >,
+    res: Response,
+  ) => {
+    const page = parsePositiveInteger(req.query.page, DEFAULT_PAGE)
+    const perPage = parsePositiveInteger(
+      req.query.perPage,
+      DEFAULT_PER_PAGE,
+      MAX_PER_PAGE,
+    )
+    const total = await prisma.post.count()
+    const posts = await prisma.post.findMany({
+      orderBy: { id: 'desc' },
+      skip: perPage * (page - 1),
+      take: perPage,
+    })
+
+    sendSuccess(res, posts, {
+      message: 'Posts retrieved',
+      meta: {
+        pagination: createPaginationMeta(page, perPage, total),
+      },
+    })
+  },
+)
+
+router.get('/v1/posts/:id', async (req: Request, res: Response) => {
+  const postId = parseRouteId(req.params.id)
+  const post = await prisma.post.findUnique({
+    where: { id: postId },
+  })
+
+  if (!post) {
+    throw notFoundError('Post')
+  }
+
+  sendSuccess(res, post, { message: 'Post retrieved' })
+})
+
+router.use('/v1', handleMissingV1Route)
+
+router.use(apiErrorHandler)
+
+export default router


### PR DESCRIPTION
## Summary
- add central API error and response helpers with request IDs and safe 500 responses
- add versioned /api/v1 posts, user-count, and OpenAPI metadata endpoints with standard envelopes
- keep legacy /api endpoints compatible while removing raw internal error leakage from server failures
- add Playwright coverage for API v1 success, validation, not-found, and docs responses

## Validation
- pnpm validate
- pnpm server:build
- CI=1 pnpm playwright e2e/api-v1.spec.ts e2e/admin/api-validation.spec.ts e2e/admin/authorization.spec.ts

Fixes #3590
Fixes #3592

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added versioned API v1 endpoints, posts listing/retrieval, and a user-count endpoint
  * API metadata endpoint (OpenAPI) for machine-readable docs

* **Bug Fixes**
  * Standardized error responses to avoid leaking internal details; consistent 400/404/500 handling

* **Documentation**
  * README updated with API v1 contract and response envelope specs

* **Tests**
  * New end-to-end tests validating v1 response contracts and input validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3768?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->