### PR TITLE
fix: normalize prisma socket url for migrations

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,7 +16,7 @@ SENTRY_TRACES_SAMPLE_RATE="0.1"
 LOG_LEVEL="info"
 # Dev (compose.dev publishes 3306): TCP
 DATABASE_URL="mysql://root:your_mysql_root_password@127.0.0.1:3306/digital"
-# Production (compose.prod, PM2 on host): no TCP; use socketPath (URL-encode path if needed)
+# Production runtime (compose.prod, PM2 on host): no TCP; Prisma CLI normalizes socketPath to socket.
 # DATABASE_URL="mysql://root:your_mysql_root_password@localhost/digital?socketPath=/path/to/nsx/run/mysqld/mysqld.sock"
 
 # Docker Compose (auto-read from .env by docker compose)

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ pm2 ps -a                        // Show all processes
 1. `source ~/.bashrc` && `volta install node`
 1. `pnpm`
 1. install docker on Ubuntu https://docs.docker.com/engine/install/ubuntu/#set-up-the-repository
-1. `docker compose -f compose.yml -f compose.prod.yml up -d` (MySQL has no host port; PM2 uses `DATABASE_URL` with `socketPath` — see `.env.sample`)
+1. `docker compose -f compose.yml -f compose.prod.yml up -d` (MySQL has no host port; PM2 runtime uses `DATABASE_URL` with `socketPath`, and Prisma CLI normalizes it for migrations — see `.env.sample`)
 1. pnpm db:migrate
 1. touch .env.prod
 1. npm i -g pm2

--- a/prisma.config.ts
+++ b/prisma.config.ts
@@ -1,6 +1,55 @@
 import 'dotenv/config'
 import { defineConfig } from 'prisma/config'
 
+const PLACEHOLDER_DATABASE_URL =
+  'mysql://placeholder:placeholder@localhost:3306/placeholder'
+const RUNTIME_SOCKET_QUERY_PARAMETER = 'socketPath'
+const PRISMA_CLI_SOCKET_QUERY_PARAMETER = 'socket'
+
+/**
+ * Converts the app runtime MySQL socket URL into the Prisma CLI socket URL.
+ * @param databaseUrl - DATABASE_URL read from the deploy environment.
+ * @returns
+ * - With socketPath: equivalent URL using Prisma's documented socket parameter
+ * - Without socketPath: the original URL
+ * - When missing: placeholder URL used only for schema parsing
+ * @example
+ * normalizeDatabaseUrlForPrismaCli('mysql://root:pass@localhost/digital?socketPath=/tmp/mysql.sock')
+ * // => 'mysql://root:pass@localhost/digital?socket=%2Ftmp%2Fmysql.sock'
+ */
+export const normalizeDatabaseUrlForPrismaCli = (
+  databaseUrl: string | undefined,
+): string => {
+  if (!databaseUrl) {
+    return PLACEHOLDER_DATABASE_URL
+  }
+
+  try {
+    const parsedDatabaseUrl = new URL(databaseUrl)
+    const socketPath = parsedDatabaseUrl.searchParams.get(
+      RUNTIME_SOCKET_QUERY_PARAMETER,
+    )
+
+    if (!socketPath) {
+      return databaseUrl
+    }
+
+    // Prisma CLI expects `socket`, while the runtime MariaDB adapter uses `socketPath`.
+    parsedDatabaseUrl.searchParams.delete(RUNTIME_SOCKET_QUERY_PARAMETER)
+    parsedDatabaseUrl.searchParams.set(
+      PRISMA_CLI_SOCKET_QUERY_PARAMETER,
+      socketPath,
+    )
+    return parsedDatabaseUrl.toString()
+  } catch {
+    // Invalid URLs should still surface through Prisma; only translate the known key.
+    return databaseUrl.replace(
+      `${RUNTIME_SOCKET_QUERY_PARAMETER}=`,
+      `${PRISMA_CLI_SOCKET_QUERY_PARAMETER}=`,
+    )
+  }
+}
+
 /**
  * Prisma v7 configuration.
  *
@@ -17,8 +66,6 @@ export default defineConfig({
     seed: 'tsx prisma/seed.ts',
   },
   datasource: {
-    url:
-      process.env.DATABASE_URL ||
-      'mysql://placeholder:placeholder@localhost:3306/placeholder',
+    url: normalizeDatabaseUrlForPrismaCli(process.env.DATABASE_URL),
   },
 })

--- a/src/lib/prismaConfig.test.ts
+++ b/src/lib/prismaConfig.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeDatabaseUrlForPrismaCli } from '../../prisma.config'
+
+describe('normalizeDatabaseUrlForPrismaCli', () => {
+  it('uses Prisma socket query when the production runtime URL contains socketPath', () => {
+    // Arrange
+    const databaseUrl =
+      'mysql://root:secret@localhost/digital?socketPath=/home/deploy/nsx/run/mysqld/mysqld.sock'
+
+    // Act
+    const normalizedDatabaseUrl = normalizeDatabaseUrlForPrismaCli(databaseUrl)
+
+    // Assert
+    expect(normalizedDatabaseUrl).toBe(
+      'mysql://root:secret@localhost/digital?socket=%2Fhome%2Fdeploy%2Fnsx%2Frun%2Fmysqld%2Fmysqld.sock',
+    )
+  })
+
+  it('keeps a TCP database URL unchanged when no socketPath query exists', () => {
+    // Arrange
+    const databaseUrl = 'mysql://root:secret@127.0.0.1:3306/digital'
+
+    // Act
+    const normalizedDatabaseUrl = normalizeDatabaseUrlForPrismaCli(databaseUrl)
+
+    // Assert
+    expect(normalizedDatabaseUrl).toBe(
+      'mysql://root:secret@127.0.0.1:3306/digital',
+    )
+  })
+
+  it('uses the schema-parse placeholder when DATABASE_URL is missing', () => {
+    // Arrange
+    const databaseUrl = undefined
+
+    // Act
+    const normalizedDatabaseUrl = normalizeDatabaseUrlForPrismaCli(databaseUrl)
+
+    // Assert
+    expect(normalizedDatabaseUrl).toBe(
+      'mysql://placeholder:placeholder@localhost:3306/placeholder',
+    )
+  })
+})


### PR DESCRIPTION
## Summary
- normalize runtime socketPath URLs to Prisma CLI's documented socket parameter in prisma.config.ts
- cover socketPath, TCP, and missing DATABASE_URL behavior with Vitest
- document the runtime/CLI socket distinction in .env.sample and README

## Root Cause
Production deploy failed because Prisma CLI read DATABASE_URL with the runtime MariaDB adapter's socketPath query. Prisma's MySQL CLI connection URL expects socket, so migrate status fell back to localhost:3306 and failed before PM2 restart.

## Validation
- pnpm test -- src/lib/prismaConfig.test.ts --watch=false
- pnpm typecheck
- git diff --check
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified production server setup instructions, including MySQL socket connection configuration and Prisma database URL normalization details.

* **Improvements**
  * Enhanced database URL handling to better support socket-based connections in production environments.

* **Tests**
  * Added test coverage for database URL normalization behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3772?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->