### PR TITLE
fix: re-extract deploy artifact after migrations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -294,6 +294,10 @@ jobs:
               ./node_modules/.bin/prisma migrate deploy
             ) || fail_deployment "Prisma migration failed; PM2 restart skipped"
 
+            # Prisma may touch generated client files during migration; re-extract a clean artifact before rsync.
+            find "$staging_dir" -mindepth 1 -delete || fail_deployment "Failed to clear migration staging directory"
+            tar -xzf "$remote_archive" -C "$staging_dir" || fail_deployment "Failed to re-extract clean deployment artifact"
+
             rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$staging_dir"/ "$remote_dir"/ || fail_deployment "Failed to sync deployment artifact"
             deployment_applied="true"
 


### PR DESCRIPTION
## Summary
- re-extract the deploy artifact after Prisma migrations before the final rsync
- avoid syncing a staging tree that Prisma may have mutated while running migrate deploy

## Root Cause
The previous deploy fixed Prisma's socket URL and migrations succeeded, but rsync then failed with vanished files under node_modules. The deploy script was using the same staging tree for migration execution and final artifact sync.

## Validation
- actionlint .github/workflows/deploy.yml
- git diff --check
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment pipeline reliability by improving the handling of generated files during database migrations, ensuring cleaner deployments with more consistent artifact state.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3773?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->