### PR TITLE
fix: tolerate rollback capture drift

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -230,6 +230,26 @@ jobs:
               fi
             }
 
+            capture_rollback_artifacts() {
+              set +e
+              rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$remote_dir"/ "$rollback_dir"/
+              rollback_status=$?
+              set -e
+
+              if [ "$rollback_status" -eq 0 ]; then
+                return 0
+              fi
+
+              if [ "$rollback_status" -eq 24 ]; then
+                # Exit 24 means rsync saw a transient file disappear; the deploy can still proceed.
+                echo "::warning::Rollback capture saw vanished files; continuing with best-effort rollback artifacts"
+                return 0
+              fi
+
+              echo "::warning::Rollback capture failed with rsync exit ${rollback_status}; continuing without rollback"
+              return 1
+            }
+
             fail_deployment() {
               message="$1"
               echo "::error::$message"
@@ -249,8 +269,9 @@ jobs:
             tar -xzf "$remote_archive" -C "$staging_dir" || fail_deployment "Failed to extract deployment artifact"
 
             if [ -d "$remote_dir/build" ] || [ -d "$remote_dir/server_build" ]; then
-              rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$remote_dir"/ "$rollback_dir"/ || fail_deployment "Failed to capture rollback artifacts"
-              rollback_ready="true"
+              if capture_rollback_artifacts; then
+                rollback_ready="true"
+              fi
             else
               echo "::warning::No previous deployment artifacts found; rollback will be unavailable"
             fi


### PR DESCRIPTION
## Summary
- wrap rollback snapshot rsync so vanished-file exit 24 does not block deployment
- continue without rollback if snapshot capture fails before new artifacts are applied

## Root Cause
The previous deploy was blocked before app sync because rollback artifact capture hit rsync code 24 from vanished files under the rollback snapshot. Rollback capture is a safety net; it should not prevent a deploy that can still migrate, sync clean artifacts, restart PM2, and pass health checks.

## Validation
- actionlint .github/workflows/deploy.yml
- git diff --check
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability with enhanced error handling during rollback preparation. The system now gracefully handles transient failures while maintaining strict error detection for critical issues, ensuring more robust deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3774?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->