### PR TITLE
fix: run prisma deploy through node

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -250,6 +250,11 @@ jobs:
               return 1
             }
 
+            run_prisma_cli() {
+              # Run Prisma through Node so deploys do not depend on executable bits in unpacked artifacts.
+              node ./node_modules/prisma/build/index.js "$@"
+            }
+
             fail_deployment() {
               message="$1"
               echo "::error::$message"
@@ -262,6 +267,7 @@ jobs:
 
             require_command curl
             require_command find
+            require_command node
             require_command rsync
             require_command tar
 
@@ -297,7 +303,7 @@ jobs:
               cd "$staging_dir"
               # Pending migrations make `status` non-zero, but drift/failed states should stop before deploy.
               set +e
-              migration_status_output=$(./node_modules/.bin/prisma migrate status 2>&1)
+              migration_status_output=$(run_prisma_cli migrate status 2>&1)
               migration_status_code=$?
               set -e
               printf '%s\n' "$migration_status_output"
@@ -309,10 +315,10 @@ jobs:
                   *)
                     echo "::error::Prisma migration status reported an unsafe state"
                     exit "$migration_status_code"
-                    ;;
-                esac
+                  ;;
+              esac
               fi
-              ./node_modules/.bin/prisma migrate deploy
+              run_prisma_cli migrate deploy
             ) || fail_deployment "Prisma migration failed; PM2 restart skipped"
 
             # Prisma may touch generated client files during migration; re-extract a clean artifact before rsync.


### PR DESCRIPTION
## Summary
- invoke Prisma CLI through Node during production deploy instead of executing the `.bin` shim
- require `node` on the remote deploy host before running migrations

## Root Cause
The latest main deploy reached the migration phase but failed with `./node_modules/.bin/prisma: Permission denied` inside the unpacked deploy artifact. The artifact contains a readable Prisma CLI entrypoint, so running it through Node avoids depending on executable bits or shim behavior during remote extraction.

## Validation
- actionlint .github/workflows/deploy.yml
- git diff --check
- node node_modules/prisma/build/index.js --version
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow for database migrations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->