### PR TITLE
fix: reset deploy staging directory safely

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,10 +144,26 @@ jobs:
 
             cleanup() {
               if [ -d "$staging_dir" ]; then
-                find "$staging_dir" -mindepth 1 -delete 2>/dev/null || true
-                rmdir "$staging_dir" 2>/dev/null || true
+                case "$staging_dir" in
+                  /tmp/nsx-deploy-*) rm -rf "$staging_dir" ;;
+                  *) echo "::warning::Skipped cleanup for unexpected staging path: $staging_dir" ;;
+                esac
               fi
               rm -f "$remote_archive"
+            }
+
+            reset_staging_dir() {
+              case "$staging_dir" in
+                /tmp/nsx-deploy-*) ;;
+                *)
+                  echo "::error::Refusing to reset unexpected staging path: $staging_dir"
+                  return 1
+                  ;;
+              esac
+
+              # Recreate staging wholesale because node_modules hardlinks can make find -delete race itself.
+              rm -rf "$staging_dir" || return 1
+              mkdir -p "$staging_dir" || return 1
             }
 
             require_command() {
@@ -271,7 +287,8 @@ jobs:
             require_command rsync
             require_command tar
 
-            mkdir -p "$remote_dir" "$staging_dir" "$rollback_dir" "$remote_dir/run/mysqld" "$remote_dir/logs" || fail_deployment "Failed to prepare deployment directories"
+            mkdir -p "$remote_dir" "$rollback_dir" "$remote_dir/run/mysqld" "$remote_dir/logs" || fail_deployment "Failed to prepare deployment directories"
+            reset_staging_dir || fail_deployment "Failed to prepare staging directory"
             tar -xzf "$remote_archive" -C "$staging_dir" || fail_deployment "Failed to extract deployment artifact"
 
             if [ -d "$remote_dir/build" ] || [ -d "$remote_dir/server_build" ]; then
@@ -322,7 +339,7 @@ jobs:
             ) || fail_deployment "Prisma migration failed; PM2 restart skipped"
 
             # Prisma may touch generated client files during migration; re-extract a clean artifact before rsync.
-            find "$staging_dir" -mindepth 1 -delete || fail_deployment "Failed to clear migration staging directory"
+            reset_staging_dir || fail_deployment "Failed to clear migration staging directory"
             tar -xzf "$remote_archive" -C "$staging_dir" || fail_deployment "Failed to re-extract clean deployment artifact"
 
             rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$staging_dir"/ "$remote_dir"/ || fail_deployment "Failed to sync deployment artifact"


### PR DESCRIPTION
## Summary
- replace `find -delete` staging cleanup with a guarded staging directory reset
- recreate staging before the initial extract and before the clean re-extract after Prisma migrations

## Root Cause
The latest deploy successfully reached Prisma and reported the database schema was up to date, but failed when `find -delete` tried to clear a large node_modules tree after migration. The log showed many `No such file or directory` entries from paths that vanished during traversal, so the deploy stopped before syncing the clean artifact.

## Validation
- actionlint .github/workflows/deploy.yml
- git diff --check
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced staging directory validation in deployment workflow with path allowlisting to ensure only expected paths are processed.
  * Updated deployment cleanup operations to use wholesale staging directory deletion and recreation.

* **Chores**
  * Refactored staging directory reset logic for more deterministic deployment operations across the workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->