### PR TITLE
fix: dereference deploy artifact hardlinks

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -80,8 +80,8 @@ jobs:
           cp -r scripts/ deploy/
           mkdir -p deploy/run/mysqld
           cp run/mysqld/.gitkeep deploy/run/mysqld/
-          # Create tar archive for efficient transfer
-          tar -czf "deploy-${{ github.run_id }}-${{ github.run_attempt }}.tar.gz" -C deploy .
+          # Store hard-linked dependencies as regular files so remote tar can extract into empty staging.
+          tar --hard-dereference -czf "deploy-${{ github.run_id }}-${{ github.run_attempt }}.tar.gz" -C deploy .
 
       - name: Upload build artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02


### PR DESCRIPTION
## Summary
- create deploy tarballs with `tar --hard-dereference`
- keep dependency contents self-contained so the remote host can extract into an empty staging directory

## Root Cause
After staging cleanup was fixed, remote extraction failed with `tar: ./node_modules/pm2: Cannot stat` and similar errors for hard-linked dependency directories. The deploy archive was relying on hardlink metadata that GNU tar could not restore into a freshly empty staging directory. Dereferencing hard links at archive creation makes the artifact independent of existing staging contents.

## Validation
- actionlint .github/workflows/deploy.yml
- git diff --check
- ssh nsx.malloc.tokyo 'tar --help | grep -- --hard-dereference'
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the deployment build process to improve handling of dependencies during artifact creation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3777?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->