### PR TITLE
fix: deploy only once per main push

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,9 +3,11 @@ name: Deploy
 on:
   push:
     branches: [main]
-  pull_request:
-    types: [closed]
-    branches: [main]
+
+# Keep production deploys serialized so remote staging and rollback paths never race.
+concurrency:
+  group: deploy-production-${{ github.ref }}
+  cancel-in-progress: false
 
 permissions:
   contents: read
@@ -14,15 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     if: >
-      (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.merged == true &&
-        github.event.pull_request.user.login != 'dependabot[bot]'
-      ) || (
-        github.event_name == 'push' &&
-        github.actor != 'dependabot[bot]' &&
-        !(contains(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, '/dependabot/'))
-      )
+      github.actor != 'dependabot[bot]' &&
+      !(contains(github.event.head_commit.message, 'Merge pull request') && contains(github.event.head_commit.message, '/dependabot/'))
 
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
@@ -136,7 +131,7 @@ jobs:
 
             remote_dir="$NSX_REMOTE_DIR"
             remote_archive="/tmp/deploy-${{ github.run_id }}-${{ github.run_attempt }}.tar.gz"
-            staging_dir="/tmp/nsx-deploy-${{ github.sha }}"
+            staging_dir="/tmp/nsx-deploy-${{ github.run_id }}-${{ github.run_attempt }}-${{ github.sha }}"
             rollback_dir="${remote_dir%/}.rollback"
             health_url="https://nsx.malloc.tokyo/api/health"
             deployment_applied="false"


### PR DESCRIPTION
## Summary
- remove the `pull_request: closed` deploy trigger so production deploys run only from main pushes
- serialize production deploy workflow runs with GitHub Actions concurrency
- include run id and attempt in the remote staging directory name

## Root Cause
Every merged PR was starting two production deploy workflows at the same time: one for `pull_request` on the branch head and one for `push` on the merge commit. Those runs touched the same production deployment directory, rollback directory, and sha-based staging path concurrently, causing the vanished files, non-empty directory cleanup failures, and tar extraction races seen in recent deploy attempts.

## Validation
- actionlint .github/workflows/deploy.yml
- git diff --check
- pnpm validate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment workflow configuration to improve production environment reliability and deployment consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3778?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->