### PR TITLE
ci: track GitHub Actions versions with Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,18 @@ updates:
       # @atproto/api 0.20.x is ESM-only and breaks this CJS Express server.
       - dependency-name: '@atproto/api'
         versions: ['0.20.x']
+
+  # Track GitHub Actions versions (checkout/setup-node/upload-artifact, the
+  # SHA-pinned ssh/scp/download-artifact actions, and the local composite
+  # action) so v4->v5 / Node 24 runtime bumps and SHA refreshes land as PRs
+  # instead of silently going stale. npm-only Dependabot left these unmanaged.
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 10
+    # Bundle all action bumps into one PR, mirroring the npm group above.
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
## What

Add a `github-actions` ecosystem to Dependabot so GitHub Actions versions are tracked and bumped automatically.

## Why

Dependabot only watched the `npm` ecosystem. GitHub Actions majors (`actions/checkout@v4`, `setup-node@v4`, `upload-artifact@v4`, `pnpm/action-setup@v4`) and the SHA-pinned actions (`appleboy/ssh-action`, `appleboy/scp-action`, `actions/download-artifact`, plus a few SHA-pinned checkout/upload calls) received **no update PRs** and were silently going stale — including the Node 24 runtime migration (v4 actions still run on Node 20).

## What changes

- New `github-actions` entry: `directory: /`, `daily` schedule, `open-pull-requests-limit: 10`.
- Grouped into a single PR (`groups.github-actions.patterns: ['*']`), mirroring the existing npm `all-dependencies` group, to keep PR noise low.
- Covers `.github/workflows/*` and the local composite action under `.github/actions/`.

## Impact

- **No production impact** — deploy triggers only on push to `main`; this is config-only.
- Expect Dependabot to open one grouped action-bump PR on its next daily run (likely `v4`→`v5` / Node 24 runtime bumps + SHA refreshes), which you review like any other.

## Test

- `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` → `YAML OK`, ecosystems `['npm', 'github-actions']`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated automated dependency management to regularly check and update GitHub Actions dependencies.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3780?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->