### PR TITLE
PR1: server test-infra split + Prisma migration safety net (E2/E1/E10)

### DIFF
--- a/scripts/deploy
+++ b/scripts/deploy
@@ -1,24 +1,91 @@
 #!/bin/bash
+#
+# Deploy NSX build artifacts to production and apply any pending Prisma migrations.
+#
+# Why migrations run here: the host PM2 process serves the bundled Express artifact
+# (server_build), but the database schema lives outside that bundle. `pnpm server:build`
+# bundles the generated Prisma *client* into server_build (it is a relative import, so
+# esbuild's --packages=external does not externalize it), yet the actual table changes
+# still have to be applied to MySQL. This mirrors .github/workflows/deploy.yml so the
+# manual deploy path carries the same migration safety net as the GitHub Actions path.
+#
+# Usage: deploy [-s] [-f]
+#   -s        server only  (migrate + server_build + ecosystem.config.js)
+#   -f        frontend only (build; no schema to migrate)
+#   no flag   full deploy   (migrate + build + server_build + ecosystem.config.js)
+#
+# After this script finishes, restart the server:
+#   ssh nsx.malloc.tokyo 'pm2 restart server'
 
-LOCAL_ROOT=$(cd $(dirname $0)/..; pwd)
+set -euo pipefail
+
+LOCAL_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+REMOTE_HOST=nsx.malloc.tokyo
 REMOTE_ROOT=/home/deploy/nsx/
 
 usage() { echo "Usage: $0 [-s] [-f]" 1>&2; exit 1; }
 
+# Ship migration SQL + schema, then apply it on the host BEFORE new server code lands,
+# so a failed migration never precedes a PM2 restart. Runs for every server-touching
+# deploy (-s and the default path); skipped for -f because the SPA has no schema.
+run_remote_migrations() {
+    # The generated client is already bundled into server_build, so only the migration
+    # files + schema + prisma config need to reach the host — no remote `prisma generate`.
+    rsync -avzhc "$LOCAL_ROOT/prisma" "$REMOTE_HOST:$REMOTE_ROOT"
+    rsync -avzhc "$LOCAL_ROOT/prisma.config.ts" "$REMOTE_HOST:$REMOTE_ROOT"
+
+    # Production login shell is fish, so force bash for the remote migration snippet.
+    ssh "$REMOTE_HOST" 'bash -s' <<'REMOTE'
+set -euo pipefail
+cd /home/deploy/nsx
+# Invoke the repo-pinned Prisma CLI exactly as .github/workflows/deploy.yml does.
+run_prisma_cli() { node ./node_modules/prisma/build/index.js "$@"; }
+
+# `migrate status` exits non-zero when migrations are pending; that case is expected and
+# falls through to `migrate deploy`. Any other non-zero state means drift/failure → abort
+# before the operator restarts PM2, so broken code never runs against an unmigrated DB.
+set +e
+status_output=$(run_prisma_cli migrate status 2>&1)
+status_code=$?
+set -e
+printf '%s\n' "$status_output"
+if [ "$status_code" -ne 0 ]; then
+    case "$status_output" in
+        *"not yet been applied"*|*"pending migrations"*)
+            echo "Pending migrations detected; applying with migrate deploy" ;;
+        *)
+            echo "ERROR: prisma migrate status reported an unsafe state; aborting before PM2 restart" >&2
+            exit "$status_code" ;;
+    esac
+fi
+
+# Apply pending migrations. A no-op that exits 0 when the schema is already up to date.
+run_prisma_cli migrate deploy
+REMOTE
+}
+
 while getopts ":sf" opt; do
     case "${opt}" in
         s)
-            rsync -avzhc $LOCAL_ROOT/server_build nsx.malloc.tokyo:$REMOTE_ROOT
-            rsync -avzhc $LOCAL_ROOT/ecosystem.config.js nsx.malloc.tokyo:$REMOTE_ROOT
+            # Server-only deploy: migrate first, then ship the Express bundle + PM2 config.
+            run_remote_migrations
+            rsync -avzhc "$LOCAL_ROOT/server_build" "$REMOTE_HOST:$REMOTE_ROOT"
+            rsync -avzhc "$LOCAL_ROOT/ecosystem.config.js" "$REMOTE_HOST:$REMOTE_ROOT"
             exit 0
             ;;
         f)
-            rsync -avzhc $LOCAL_ROOT/build nsx.malloc.tokyo:$REMOTE_ROOT
+            # Frontend-only deploy: static SPA assets, no database schema involved.
+            rsync -avzhc "$LOCAL_ROOT/build" "$REMOTE_HOST:$REMOTE_ROOT"
             exit 0
+            ;;
+        *)
+            usage
             ;;
     esac
 done
 
-rsync -avzhc $LOCAL_ROOT/build nsx.malloc.tokyo:$REMOTE_ROOT
-rsync -avzhc $LOCAL_ROOT/server_build nsx.malloc.tokyo:$REMOTE_ROOT
-rsync -avzhc $LOCAL_ROOT/ecosystem.config.js nsx.malloc.tokyo:$REMOTE_ROOT
+# Full deploy: migrate before shipping new server code, then push every artifact.
+run_remote_migrations
+rsync -avzhc "$LOCAL_ROOT/build" "$REMOTE_HOST:$REMOTE_ROOT"
+rsync -avzhc "$LOCAL_ROOT/server_build" "$REMOTE_HOST:$REMOTE_ROOT"
+rsync -avzhc "$LOCAL_ROOT/ecosystem.config.js" "$REMOTE_HOST:$REMOTE_ROOT"

--- a/server/lib/authenticateStockRequest.contract.test.ts
+++ b/server/lib/authenticateStockRequest.contract.test.ts
@@ -1,0 +1,47 @@
+import { describe, it } from 'vitest'
+
+/**
+ * Contract placeholder for the scoped-PAT stock-write middleware.
+ *
+ * Exists so the regression guards for `authenticateStockRequest` (the dedicated
+ * middleware introduced in PR2 / #3784) are captured in the test tree before the
+ * implementation lands. Each `it.todo` names an observable behavior the middleware
+ * MUST satisfy; PR2 replaces every `it.todo` with a real DB-backed assertion
+ * (U5–U8 in eng-review-test-plan-20260528-104950.md). The server vitest project
+ * collects this file in the Node environment (see vitest.config.ts).
+ *
+ * Kept import-free of the middleware itself because that symbol does not exist
+ * until PR2 — adding the import now would break collection in PR1.
+ */
+describe('authenticateStockRequest contract (filled in by PR2 / #3784)', () => {
+  // Happy path: a valid Bearer PAT authorizes a stock write without a cookie session.
+  it.todo('authenticates a stock write when a valid Bearer PAT is supplied')
+
+  // E4: the PAT branch must hydrate the same full user shape the cookie branch does.
+  it.todo(
+    'hydrates req.authenticatedUser with the full session-user shape for a PAT request',
+  )
+
+  // E14: revoked / expired tokens are filtered inside one atomic lookup, not in JS.
+  it.todo(
+    'validates the PAT in a single atomic query that excludes revoked and expired tokens',
+  )
+
+  // U8: successful PAT auth records lastUsedAt for owner visibility.
+  it.todo('updates lastUsedAt after a successful PAT authentication')
+
+  // U7: absent Authorization header leaves the existing cookie-session path untouched.
+  it.todo(
+    'falls back to the existing cookie session when no Authorization header is present',
+  )
+
+  // U5 (confused-deputy guard): an invalid/revoked Bearer PAT must NOT clear the owner's auth cookies.
+  it.todo(
+    'responds 401 without clearing auth cookies when the Bearer PAT is invalid or revoked',
+  )
+
+  // U6: a malformed Authorization header is a client error (401), never a server error (500).
+  it.todo(
+    'responds 401 rather than 500 when the Authorization header is malformed',
+  )
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -3,41 +3,67 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 import { defineConfig } from 'vitest/config'
-// TODO move to const ad DIR_NAME
-const dirname =
+
+// Resolve the project root for path aliases; `__dirname` is undefined under ESM.
+const DIR_NAME =
   typeof __dirname !== 'undefined'
     ? __dirname
     : path.dirname(fileURLToPath(import.meta.url))
+
+// Patterns excluded from every project (build output, vendored deps, Storybook, the WXT extension).
+const SHARED_EXCLUDE = [
+  '**/node_modules/**',
+  '**/dist/**',
+  '**/cypress/**',
+  '**/.{idea,git,cache,output,temp}/**',
+  '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
+  '**/*.storybook.test.*', // Exclude storybook tests for now
+  '**/browser-extension/**',
+]
 
 // More info at: https://storybook.js.org/docs/next/writing-tests/integrations/vitest-addon
 export default defineConfig({
   resolve: {
     alias: {
-      '@': path.resolve(dirname, './'),
-      '@/src': path.resolve(dirname, './src'),
+      '@': path.resolve(DIR_NAME, './'),
+      '@/src': path.resolve(DIR_NAME, './src'),
     },
   },
   optimizeDeps: {
     include: ['@mdx-js/react', 'markdown-to-jsx'],
   },
   test: {
-    environment: 'jsdom',
-    globals: true,
-    include: [
-      'src/**/*.{spec,test}.{js,jsx,ts,tsx}',
-      'src/**/__tests__/**/*.{js,jsx,ts,tsx}',
-      'lib/**/*.{spec,test}.{js,jsx,ts,tsx}',
-      'scripts/**/*.{spec,test}.{js,jsx,ts,tsx}',
+    // Two projects so Express/server tests run in Node without the jsdom-only
+    // setup (setupTests.ts builds a MatchMediaMock that needs `window`).
+    projects: [
+      {
+        // Frontend SPA + shared lib + scripts: jsdom env with DOM test setup (MSW, matchMedia, jest-dom).
+        extends: true,
+        test: {
+          name: 'web',
+          environment: 'jsdom',
+          globals: true,
+          include: [
+            'src/**/*.{spec,test}.{js,jsx,ts,tsx}',
+            'src/**/__tests__/**/*.{js,jsx,ts,tsx}',
+            'lib/**/*.{spec,test}.{js,jsx,ts,tsx}',
+            'scripts/**/*.{spec,test}.{js,jsx,ts,tsx}',
+          ],
+          exclude: SHARED_EXCLUDE,
+          setupFiles: ['setupTests.ts'],
+        },
+      },
+      {
+        // Express API/server unit tests: Node env, no DOM setup. Foundation for the PAT auth tests (PR2).
+        extends: true,
+        test: {
+          name: 'server',
+          environment: 'node',
+          globals: true,
+          include: ['server/**/*.{spec,test}.{ts,tsx}'],
+          exclude: SHARED_EXCLUDE,
+        },
+      },
     ],
-    exclude: [
-      '**/node_modules/**',
-      '**/dist/**',
-      '**/cypress/**',
-      '**/.{idea,git,cache,output,temp}/**',
-      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build}.config.*',
-      '**/*.storybook.test.*', // Exclude storybook tests for now
-      '**/browser-extension/**',
-    ],
-    setupFiles: ['setupTests.ts'],
   },
 })


### PR DESCRIPTION
## Summary

Safety-net PR for the extension-login-flow feature (the scoped-PAT feature itself lands in #3784). Three independent, low-risk changes that make PR2 safe to build on:

**E2 — Vitest web/server project split** (`vitest.config.ts`)
A single jsdom project forced `setupTests.ts`'s `window.matchMedia` mock onto every test, which throws in Node and blocks DB-free Express unit tests. Split into two Vitest 4 projects: `web` (jsdom + setupTests, for the SPA / lib / scripts) and `server` (node, no DOM setup, for `server/**`). `JWT.test.ts` (8 tests) now runs under the server project. This is the foundation PR2's PAT-middleware unit tests (U1–U8) build on.

**E1 — PAT middleware contract placeholder** (`server/lib/authenticateStockRequest.contract.test.ts`)
7 `it.todo` capturing the regression guards the PR2 `authenticateStockRequest` middleware must satisfy — U5 (invalid/revoked PAT must NOT clear the owner's auth cookies / confused-deputy), U6 (malformed header → 401 not 500), U7 (cookie fallback when no `Authorization` header), U8 (`lastUsedAt` update), E4 (full session-user hydrate), E14 (single atomic revoked/expired query). It imports nothing from the not-yet-existent middleware so collection stays green; PR2 replaces each todo with a real DB-backed assertion.

**E10 — Prisma migrations in the manual deploy script** (`scripts/deploy`)
`pnpm deploy` shipped `server_build` but never ran migrations, so a new table (PR2 adds `personal_access_tokens`) would be missing on the host after a manual deploy. The script now rsyncs `prisma/` and runs `migrate status` → `migrate deploy` on the host **before** the server restarts, aborting on drift/failure — mirroring the existing `.github/workflows/deploy.yml` safety net. No remote `prisma generate` is needed: esbuild bundles the Prisma client into `server_build` (the `../generated/prisma` import is relative, so `--packages=external` doesn't externalize it).

## Test Coverage

Test-infra / deploy-script changes — no new application code paths. The new contract test is itself the coverage scaffold for PR2.

- **typecheck**: ✅ `tsc --noEmit` clean
- **lint**: ✅ eslint `--max-warnings=0` clean
- **test**: ✅ 33 files passed | 1 skipped, 79 passed | 7 todo — the "1 skipped" file is the new contract test (all 7 of its tests are `it.todo` placeholders, so the file has no executable tests yet)

## Pre-Landing Review

Self-reviewed and reviewed by the advisor model (the E10 migrate-before-code ordering and the projects split). The E10 ordering was corrected to run `migrate deploy` **before** the code rsync, so a failed migration never precedes a PM2 restart. External review by **CodeRabbit** is expected on this PR.

Intentional behavior changes in `scripts/deploy` (flagged for the reviewer):
- adds `set -euo pipefail` and quotes rsync paths
- wires the previously-dead `usage()` into the getopts `*)` case — unknown flags now error instead of silently doing a full deploy
- `-s` and the default path now migrate; `-f` (frontend-only) skips migrations

## Verification

Production-verified the migrate mechanism (the owner took a DB backup and authorized prod verification): on the live host, `migrate status` → "Database schema is up to date!" (exit 0) and `migrate deploy` → "No pending migrations to apply." (exit 0). This confirms the abort-on-nonzero logic does not false-trip on a clean deploy. PR1 itself adds no migration, so applying it is a no-op — the real exercise is PR2's `personal_access_tokens` table.

## Notes

This is a focused 3-file safety-net PR. The heavier gstack review passes (specialist army, Codex multi-pass) were skipped as redundant for an infra-only diff that already has advisor review, production verification, and an incoming CodeRabbit review. Rollback is trivial (revert; no schema or runtime behavior changes in PR1).

Closes #3783

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment process with improved database migration ordering to ensure safer server deployments
  * Updated test infrastructure configuration to support isolated test environments

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3785?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->