### PR TITLE
feat: scoped Personal Access Token auth for browser-extension stock writes

### DIFF
--- a/@types/response.d.ts
+++ b/@types/response.d.ts
@@ -58,6 +58,38 @@ declare namespace Res {
   declare interface DeleteStock {
     success: true
   }
+
+  /**
+   * A Personal Access Token as exposed to the Settings UI (masked — never the raw value).
+   */
+  declare interface PersonalAccessToken {
+    id: number
+    name: string
+    tokenSuffix: string
+    createdAt: string
+    lastUsedAt: string | null
+    revokedAt: string | null
+  }
+
+  // GET /api/personal_access_token/list
+  declare interface PersonalAccessTokenList {
+    tokens: Res.PersonalAccessToken[]
+  }
+
+  // POST /api/personal_access_token — `token` is the raw value, returned exactly once.
+  declare interface MintPersonalAccessToken {
+    id: number
+    name: string
+    tokenSuffix: string
+    createdAt: string
+    token: string
+  }
+
+  // DELETE /api/personal_access_token/:id
+  declare interface RevokePersonalAccessToken {
+    id: number
+    revokedAt: string
+  }
   /**
    * API Reqest/Response body types
    */

--- a/browser-extension/.env.development
+++ b/browser-extension/.env.development
@@ -1,0 +1,3 @@
+# Development environment variables for WXT
+# Origin only — buildPushStockApiUrl appends /api/push_stock (and derives /api/stock/exists).
+VITE_API_ENDPOINT=http://localhost:4000

--- a/browser-extension/.env.production
+++ b/browser-extension/.env.production
@@ -1,0 +1,3 @@
+# Production environment variables for WXT
+# Origin only — buildPushStockApiUrl appends /api/push_stock (and derives /api/stock/exists).
+VITE_API_ENDPOINT=https://nsx.malloc.tokyo

--- a/browser-extension/.gitignore
+++ b/browser-extension/.gitignore
@@ -1,9 +1,14 @@
 dist
 node_modules
 output
+.output
 .wxt
 tmp
 .env*
+# Shared, non-secret build config (public API origins) must ship so CI/prod builds
+# inject VITE_API_ENDPOINT instead of falling back to the localhost default (E3/NSX-80).
+!.env.development
+!.env.production
 .idea
 test-results/
 coverage/

--- a/browser-extension/src/entrypoints/popup/App.tsx
+++ b/browser-extension/src/entrypoints/popup/App.tsx
@@ -5,15 +5,22 @@ import { setBookmarkedIcon } from '../../lib/setBookmarkIcon'
 
 import {
   ALREADY_EXISTS_MESSAGE,
+  CONNECT_PROMPT_MESSAGE,
+  CONNECTED_MESSAGE,
   DEFAULT_API_ENDPOINT,
   FAILED_MESSAGE,
   FEEDBACK_CLEAR_DELAY_MS,
+  RECONNECT_PROMPT_MESSAGE,
   SUCCESS_MESSAGE,
 } from './constants'
 import { useGetPageInfo } from './useGetPageInfo'
+import { usePersonalAccessToken } from './usePersonalAccessToken'
 import { buildPushStockApiUrl } from './utils/buildPushStockApiUrl'
 import { buildStockExistsUrl } from './utils/buildStockExistsUrl'
+import { buildStockRequestConfig } from './utils/buildStockRequestConfig'
 import { isConflictResponse } from './utils/isConflictResponse'
+import { isUnauthorizedResponse } from './utils/isUnauthorizedResponse'
+import { logStockRequestError } from './utils/logStockRequestError'
 import { normalizePopupUrl } from './utils/normalizePopupUrl'
 
 export interface PopupState {
@@ -45,12 +52,26 @@ const INITIAL_STOCK_SAVE_STATE: StockSaveState = {
 
 /**
  * Renders the NSX extension popup and coordinates duplicate-aware page saves.
- * @returns The popup UI for saving the current tab and composing a tweet.
+ *
+ * Authenticates stock reads/writes with a pasted Personal Access Token (Bearer header); the save
+ * checkbox stays usable whether or not a token is connected, and a rejected token (401) reveals an
+ * additive reconnect prompt without blocking the existing flow.
+ * @returns The popup UI for connecting a token, saving the current tab, and composing a tweet.
  * @example
  * <App />
  */
 const App: FC = () => {
   const state = useGetPageInfo()
+  const {
+    token,
+    isLoading: isTokenLoading,
+    needsReconnect,
+    inputToken,
+    setInputToken,
+    connect,
+    disconnect,
+    markRejected,
+  } = usePersonalAccessToken()
   const [comment, setComment] = useState<string>('')
   const [stockSaveState, setStockSaveState] = useState<StockSaveState>(
     INITIAL_STOCK_SAVE_STATE,
@@ -58,6 +79,9 @@ const App: FC = () => {
   const normalizedUrl = normalizePopupUrl(state.url)
 
   useEffect(() => {
+    // Wait until the stored token is known so the existence check carries the Bearer header.
+    if (isTokenLoading) return undefined
+
     const pushStockApiUrl = buildPushStockApiUrl(
       import.meta.env.VITE_API_ENDPOINT || DEFAULT_API_ENDPOINT,
     )
@@ -72,6 +96,7 @@ const App: FC = () => {
     axios
       .get<StockExistsResponse>(
         buildStockExistsUrl(pushStockApiUrl, normalizedUrl),
+        buildStockRequestConfig(token),
       )
       .then(({ data }) => {
         if (isRequestCanceled) return
@@ -84,8 +109,11 @@ const App: FC = () => {
 
         if (data.exists) setBookmarkedIcon()
       })
-      .catch(() => {
+      .catch((error: unknown) => {
         if (isRequestCanceled) return
+
+        // A rejected stored token (revoked/expired) surfaces the reconnect prompt.
+        if (token && isUnauthorizedResponse(error)) markRejected()
 
         // Existence check failures should not block saving a new page.
         setStockSaveState(INITIAL_STOCK_SAVE_STATE)
@@ -94,7 +122,7 @@ const App: FC = () => {
     return () => {
       isRequestCanceled = true
     }
-  }, [normalizedUrl])
+  }, [normalizedUrl, token, isTokenLoading, markRejected])
 
   /**
    * Shows a temporary result message after save attempts complete.
@@ -153,10 +181,14 @@ const App: FC = () => {
     }
 
     axios
-      .post(pushStockApiUrl, {
-        pageTitle: state.pageTitle,
-        url: normalizedUrl,
-      })
+      .post(
+        pushStockApiUrl,
+        {
+          pageTitle: state.pageTitle,
+          url: normalizedUrl,
+        },
+        buildStockRequestConfig(token),
+      )
       .then(() => {
         showTemporaryFeedback(SUCCESS_MESSAGE)
         setBookmarkedIcon()
@@ -172,17 +204,76 @@ const App: FC = () => {
           return
         }
 
+        // A rejected stored token reveals the reconnect prompt without hiding the Failed result.
+        if (token && isUnauthorizedResponse(error)) markRejected()
+
         setStockSaveState((currentState) => ({
           ...currentState,
           isChecked: false,
         }))
         showTemporaryFeedback(FAILED_MESSAGE)
-        console.error(JSON.stringify(error))
+        logStockRequestError(error)
       })
   }
 
+  // Show the paste panel before connecting, or after a stored token is rejected.
+  const shouldShowPastePanel = !token || needsReconnect
+
   return (
     <main>
+      {shouldShowPastePanel ? (
+        <section className="pat-connect" data-testid="pat-connect-panel">
+          <label className="pat-connect-label" htmlFor="pat-input">
+            {CONNECT_PROMPT_MESSAGE}
+          </label>
+          <input
+            id="pat-input"
+            className="pat-input"
+            data-testid="pat-input"
+            type="password"
+            value={inputToken}
+            placeholder="nsx_pat_…"
+            aria-label="NSX extension token"
+            onChange={(event): void => setInputToken(event.target.value)}
+          />
+          <button
+            type="button"
+            className="pat-connect-btn"
+            data-testid="pat-connect-btn"
+            disabled={inputToken.trim().length === 0}
+            onClick={(): void => {
+              void connect()
+            }}
+          >
+            Connect
+          </button>
+        </section>
+      ) : (
+        <section className="pat-connected" data-testid="pat-connected-status">
+          <span className="pat-connected-label">{CONNECTED_MESSAGE}</span>
+          <button
+            type="button"
+            className="pat-disconnect-btn"
+            data-testid="pat-disconnect-btn"
+            onClick={(): void => {
+              void disconnect()
+            }}
+          >
+            Disconnect
+          </button>
+        </section>
+      )}
+
+      {needsReconnect ? (
+        <p
+          role="alert"
+          className="pat-reconnect-notice"
+          data-testid="pat-reconnect-notice"
+        >
+          {RECONNECT_PROMPT_MESSAGE}
+        </p>
+      ) : null}
+
       <section className="row1">
         <div className="title">
           {state.pageTitle.length ? state.pageTitle : ''}

--- a/browser-extension/src/entrypoints/popup/constants.ts
+++ b/browser-extension/src/entrypoints/popup/constants.ts
@@ -3,3 +3,14 @@ export const DEFAULT_API_ENDPOINT = 'http://localhost:4000/api/'
 export const FAILED_MESSAGE = 'Failed...'
 export const FEEDBACK_CLEAR_DELAY_MS = 1000
 export const SUCCESS_MESSAGE = 'Success!'
+
+// chrome.storage.local key holding the pasted NSX Personal Access Token (raw `nsx_pat_…`).
+export const PAT_STORAGE_KEY = 'nsx_pat'
+// Prompt shown when no token is connected yet.
+export const CONNECT_PROMPT_MESSAGE =
+  'Paste your NSX token to save pages from this extension.'
+// Alert shown when a stored token is rejected (revoked/expired) by the API with 401.
+export const RECONNECT_PROMPT_MESSAGE =
+  'Your saved token was rejected. Paste a new token to reconnect.'
+// Label shown when a valid token is connected.
+export const CONNECTED_MESSAGE = 'Connected to NSX'

--- a/browser-extension/src/entrypoints/popup/style.css
+++ b/browser-extension/src/entrypoints/popup/style.css
@@ -13,9 +13,66 @@ body {
 
 main {
   width: 500px;
-  height: 80px;
+  min-height: 80px;
   display: flex;
   flex-wrap: wrap;
+}
+
+/* Personal Access Token connect / reconnect panel (additive; sits above the save rows). */
+.pat-connect,
+.pat-connected {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-bottom: 6px;
+  margin-bottom: 6px;
+  border-bottom: 1px solid #e5e7eb;
+  font-size: 13px;
+}
+
+.pat-connect-label {
+  flex-shrink: 0;
+  color: #6b7280;
+}
+
+.pat-input {
+  flex: 1 1 auto;
+  min-width: 0;
+  font-family: inherit;
+  font-size: 13px;
+  padding: 4px 6px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+}
+
+.pat-connect-btn,
+.pat-disconnect-btn {
+  flex-shrink: 0;
+  font-size: 13px;
+  padding: 4px 10px;
+  border: 1px solid #d1d5db;
+  border-radius: 4px;
+  background: #f9fafb;
+  cursor: pointer;
+}
+
+.pat-connect-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.pat-connected-label {
+  flex: 1 1 auto;
+  color: #16a34a;
+  font-weight: 500;
+}
+
+.pat-reconnect-notice {
+  width: 100%;
+  margin: 0 0 6px;
+  color: #dc2626;
+  font-size: 13px;
 }
 
 .row1 {

--- a/browser-extension/src/entrypoints/popup/usePersonalAccessToken.ts
+++ b/browser-extension/src/entrypoints/popup/usePersonalAccessToken.ts
@@ -40,13 +40,18 @@ export const usePersonalAccessToken = (): PersonalAccessTokenState => {
   const [inputToken, setInputToken] = useState<string>('')
 
   // Read the stored token once on mount; the guard avoids a setState after unmount.
+  // .finally clears isLoading even if the storage read rejects, so a failed read
+  // can't pin isLoading=true and stall App's existence-check effect forever.
   useEffect(() => {
     let isActive = true
-    readStoredPatToken().then((storedToken) => {
-      if (!isActive) return
-      setToken(storedToken)
-      setIsLoading(false)
-    })
+    readStoredPatToken()
+      .then((storedToken) => {
+        if (!isActive) return
+        setToken(storedToken)
+      })
+      .finally(() => {
+        if (isActive) setIsLoading(false)
+      })
     return () => {
       isActive = false
     }

--- a/browser-extension/src/entrypoints/popup/usePersonalAccessToken.ts
+++ b/browser-extension/src/entrypoints/popup/usePersonalAccessToken.ts
@@ -1,0 +1,85 @@
+import { useCallback, useEffect, useState } from 'react'
+
+import {
+  clearStoredPatToken,
+  readStoredPatToken,
+  writeStoredPatToken,
+} from './utils/patStorage'
+
+export interface PersonalAccessTokenState {
+  /** The connected raw token, or null when no valid token is stored. */
+  token: string | null
+  /** True while the initial chrome.storage.local read is in flight. */
+  isLoading: boolean
+  /** True when a stored token was rejected with 401 and the owner should re-paste. */
+  needsReconnect: boolean
+  /** Controlled value of the paste input. */
+  inputToken: string
+  /** Updates the paste input value. */
+  setInputToken: (value: string) => void
+  /** Stores the trimmed paste-input token and marks the extension connected. */
+  connect: () => Promise<void>
+  /** Clears the stored token and returns to the disconnected state. */
+  disconnect: () => Promise<void>
+  /** Flags that the stored token was rejected so the reconnect prompt appears. */
+  markRejected: () => void
+}
+
+/**
+ * Owns the extension PAT for the popup save flow: loads it from chrome.storage.local on mount,
+ * exposes connect/disconnect, and flags reconnect when a stored token is rejected with 401.
+ * Extracted from App so the component keeps a single state cluster (per the 3+ useState rule).
+ * @returns Token state plus the paste-input value and connect/disconnect/markRejected actions.
+ * @example
+ * const { token, inputToken, setInputToken, connect } = usePersonalAccessToken()
+ */
+export const usePersonalAccessToken = (): PersonalAccessTokenState => {
+  const [token, setToken] = useState<string | null>(null)
+  const [isLoading, setIsLoading] = useState<boolean>(true)
+  const [needsReconnect, setNeedsReconnect] = useState<boolean>(false)
+  const [inputToken, setInputToken] = useState<string>('')
+
+  // Read the stored token once on mount; the guard avoids a setState after unmount.
+  useEffect(() => {
+    let isActive = true
+    readStoredPatToken().then((storedToken) => {
+      if (!isActive) return
+      setToken(storedToken)
+      setIsLoading(false)
+    })
+    return () => {
+      isActive = false
+    }
+  }, [])
+
+  const connect = useCallback(async (): Promise<void> => {
+    const trimmedToken = inputToken.trim()
+    if (!trimmedToken) return
+    await writeStoredPatToken(trimmedToken)
+    setToken(trimmedToken)
+    setNeedsReconnect(false)
+    setInputToken('')
+  }, [inputToken])
+
+  const disconnect = useCallback(async (): Promise<void> => {
+    await clearStoredPatToken()
+    setToken(null)
+    setNeedsReconnect(false)
+  }, [])
+
+  // Stable so the existence-check effect can depend on it without re-running each render.
+  const markRejected = useCallback((): void => {
+    setNeedsReconnect(true)
+  }, [])
+
+  return {
+    token,
+    isLoading,
+    needsReconnect,
+    inputToken,
+    setInputToken,
+    connect,
+    disconnect,
+    markRejected,
+  }
+}

--- a/browser-extension/src/entrypoints/popup/utils/buildStockRequestConfig.ts
+++ b/browser-extension/src/entrypoints/popup/utils/buildStockRequestConfig.ts
@@ -1,0 +1,16 @@
+import type { AxiosRequestConfig } from 'axios'
+
+/**
+ * Builds the axios config for stock read/write requests, attaching the PAT as a Bearer header when connected.
+ * @param token - The stored `nsx_pat_…` token, or null when the extension is not connected.
+ * @returns
+ * - When a token exists: a config with `Authorization: Bearer <token>`
+ * - When null: an empty config (request falls back to the API's cookie path → 401 on writes)
+ * @example
+ * buildStockRequestConfig('nsx_pat_x') // => { headers: { Authorization: 'Bearer nsx_pat_x' } }
+ * buildStockRequestConfig(null)        // => {}
+ */
+export const buildStockRequestConfig = (
+  token: string | null,
+): AxiosRequestConfig =>
+  token ? { headers: { Authorization: `Bearer ${token}` } } : {}

--- a/browser-extension/src/entrypoints/popup/utils/isUnauthorizedResponse.ts
+++ b/browser-extension/src/entrypoints/popup/utils/isUnauthorizedResponse.ts
@@ -1,0 +1,12 @@
+import axios from 'axios'
+
+/**
+ * Detects a 401 from the stock API so a rejected stored PAT can trigger the reconnect prompt.
+ * @param error - The unknown error value thrown by axios.
+ * @returns Whether the backend responded with HTTP 401 Unauthorized.
+ * @example
+ * isUnauthorizedResponse(error) // => true
+ */
+export const isUnauthorizedResponse = (error: unknown): boolean => {
+  return axios.isAxiosError(error) && error.response?.status === 401
+}

--- a/browser-extension/src/entrypoints/popup/utils/logStockRequestError.ts
+++ b/browser-extension/src/entrypoints/popup/utils/logStockRequestError.ts
@@ -1,0 +1,21 @@
+import axios from 'axios'
+
+/**
+ * Logs a stock-request failure without leaking the Authorization header or raw PAT.
+ *
+ * Replaces `console.error(JSON.stringify(error))`, whose axios `toJSON()` payload carries
+ * `config.headers` (the Bearer token). Logs only the HTTP status + message, never the config.
+ * @param error - The unknown error thrown by axios during a stock read/write.
+ * @returns Nothing; writes one redacted line to the console.
+ * @example
+ * logStockRequestError(error) // logs "Stock request failed: status=401 message=Request failed with status code 401"
+ */
+export const logStockRequestError = (error: unknown): void => {
+  if (axios.isAxiosError(error)) {
+    console.error(
+      `Stock request failed: status=${error.response?.status ?? 'unknown'} message=${error.message}`,
+    )
+    return
+  }
+  console.error('Stock request failed: unknown error')
+}

--- a/browser-extension/src/entrypoints/popup/utils/patStorage.ts
+++ b/browser-extension/src/entrypoints/popup/utils/patStorage.ts
@@ -1,0 +1,36 @@
+import { PAT_STORAGE_KEY } from '../constants'
+
+/**
+ * Reads the saved NSX PAT from chrome.storage.local; runs on popup mount and before each stock request.
+ * @returns The raw `nsx_pat_…` token string, or null when nothing valid is stored.
+ * @example
+ * await readStoredPatToken() // => 'nsx_pat_abc…'  (or null when not connected)
+ */
+export const readStoredPatToken = async (): Promise<string | null> => {
+  const storedItems = await chrome.storage.local.get(PAT_STORAGE_KEY)
+  const storedToken = storedItems[PAT_STORAGE_KEY]
+  return typeof storedToken === 'string' && storedToken.length > 0
+    ? storedToken
+    : null
+}
+
+/**
+ * Persists the pasted PAT so later popup opens stay connected; called when the owner clicks Connect.
+ * @param rawToken - The raw `nsx_pat_…` token to store.
+ * @returns Nothing once the value is written to chrome.storage.local.
+ * @example
+ * await writeStoredPatToken('nsx_pat_abc…')
+ */
+export const writeStoredPatToken = async (rawToken: string): Promise<void> => {
+  await chrome.storage.local.set({ [PAT_STORAGE_KEY]: rawToken })
+}
+
+/**
+ * Removes the stored PAT; called when the owner disconnects (token rejection keeps the value for re-paste UX).
+ * @returns Nothing once the value is cleared from chrome.storage.local.
+ * @example
+ * await clearStoredPatToken()
+ */
+export const clearStoredPatToken = async (): Promise<void> => {
+  await chrome.storage.local.remove(PAT_STORAGE_KEY)
+}

--- a/browser-extension/tests/e2e/api-integration.spec.ts
+++ b/browser-extension/tests/e2e/api-integration.spec.ts
@@ -164,8 +164,9 @@ test.describe('Extension API Integration Tests', () => {
     await popupPage.close()
   })
 
-  // Skipped: VITE_API_ENDPOINT not being built into extension - See https://plane.so (NSX-80)
-  test.skip('uses correct VITE_API_ENDPOINT from environment', async ({
+  // NSX-80 fixed: .env.{development,production} now set VITE_API_ENDPOINT (origin only),
+  // which WXT/Vite injects into the build so buildPushStockApiUrl targets the real backend.
+  test('uses correct VITE_API_ENDPOINT from environment', async ({
     context,
     extensionId,
     page,

--- a/browser-extension/tests/e2e/api-integration.spec.ts
+++ b/browser-extension/tests/e2e/api-integration.spec.ts
@@ -179,6 +179,17 @@ test.describe('Extension API Integration Tests', () => {
 
     const popupPage = await openPopup(context, extensionId)
 
+    // Stub the save POST so it succeeds without a connected PAT; this test never
+    // pastes a token, so the real /api/push_stock would 401 (auth added in this PR)
+    // and verifySuccessMessage would always be false — masking a failed save.
+    await popupPage.route('**/api/push_stock**', (route) => {
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ success: true }),
+      })
+    })
+
     // Monitor API calls
     let apiUrl: string | null = null
     popupPage.on('request', async (request) => {
@@ -191,7 +202,9 @@ test.describe('Extension API Integration Tests', () => {
     const checkbox = popupPage.locator('.checkbox')
     await checkbox.check()
 
-    await verifySuccessMessage(popupPage)
+    // Assert the save actually succeeded so the URL checks below run on a real save.
+    const success = await verifySuccessMessage(popupPage)
+    expect(success).toBe(true)
 
     // Verify URL points to correct backend
     expect(apiUrl).not.toBeNull()

--- a/browser-extension/tests/setup.ts
+++ b/browser-extension/tests/setup.ts
@@ -1,9 +1,8 @@
-import * as matchers from '@testing-library/jest-dom/matchers'
+// Registers jest-dom matchers AND augments Vitest's `expect` types
+// (toBeInTheDocument, toBeEnabled, …) so component tests type-check under tsc.
+import '@testing-library/jest-dom/vitest'
 import { cleanup } from '@testing-library/react'
-import { expect, afterEach, vi } from 'vitest'
-
-// Extend Vitest matchers with jest-dom
-expect.extend(matchers)
+import { afterEach, vi } from 'vitest'
 
 // Cleanup after each test
 afterEach(() => {

--- a/browser-extension/tests/unit/entrypoints/popup/App.test.tsx
+++ b/browser-extension/tests/unit/entrypoints/popup/App.test.tsx
@@ -1,0 +1,122 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { render, screen, waitFor } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import axios from 'axios'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import App from '@/entrypoints/popup/App'
+
+// Keep axios.isAxiosError real (isConflictResponse/isUnauthorizedResponse depend on it);
+// only stub the network methods the popup calls.
+vi.mock('axios', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('axios')>()
+  return {
+    ...actual,
+    default: {
+      ...actual.default,
+      get: vi.fn(),
+      post: vi.fn(),
+      isAxiosError: actual.default.isAxiosError,
+    },
+  }
+})
+
+const RAW_TOKEN = `nsx_pat_${'a'.repeat(64)}`
+const PUSH_STOCK_URL = 'http://localhost:4000/api/push_stock'
+const ACTIVE_TAB = { url: 'https://example.com', title: 'Example Page' }
+
+/**
+ * Points chrome.tabs.query at one ordinary tab so useGetPageInfo resolves a saveable URL/title.
+ * @returns Nothing; configures the global chrome mock for the current test.
+ */
+const stubActiveTab = (): void => {
+  ;(chrome.tabs.query as any).mockResolvedValue([ACTIVE_TAB])
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  // Existence check resolves "not saved" by default so the save checkbox is enabled.
+  ;(axios.get as any).mockResolvedValue({ data: { exists: false } })
+  ;(chrome.storage.local.set as any).mockResolvedValue(undefined)
+  ;(chrome.storage.local.remove as any).mockResolvedValue(undefined)
+})
+
+describe('Extension popup token connection', () => {
+  it('shows the paste panel and hides connected status when no token is stored', async () => {
+    // Arrange
+    ;(chrome.storage.local.get as any).mockResolvedValue({})
+    stubActiveTab()
+
+    // Act
+    render(<App />)
+
+    // Assert
+    expect(await screen.findByTestId('pat-connect-panel')).toBeInTheDocument()
+    expect(screen.queryByTestId('pat-connected-status')).not.toBeInTheDocument()
+  })
+
+  it('persists the pasted token to chrome.storage.local and reveals the connected state', async () => {
+    // Arrange
+    ;(chrome.storage.local.get as any).mockResolvedValue({})
+    stubActiveTab()
+    const user = userEvent.setup()
+    render(<App />)
+    await screen.findByTestId('pat-connect-panel')
+
+    // Act
+    await user.type(screen.getByTestId('pat-input'), RAW_TOKEN)
+    await user.click(screen.getByTestId('pat-connect-btn'))
+
+    // Assert
+    expect(chrome.storage.local.set).toHaveBeenCalledWith({
+      nsx_pat: RAW_TOKEN,
+    })
+    expect(
+      await screen.findByTestId('pat-connected-status'),
+    ).toBeInTheDocument()
+  })
+
+  it('attaches the token as a Bearer Authorization header on the save request', async () => {
+    // Arrange
+    ;(chrome.storage.local.get as any).mockResolvedValue({ nsx_pat: RAW_TOKEN })
+    ;(axios.post as any).mockResolvedValue({ data: {} })
+    stubActiveTab()
+    const user = userEvent.setup()
+    render(<App />)
+    const saveCheckbox = await screen.findByRole('checkbox')
+    await waitFor(() => expect(saveCheckbox).toBeEnabled())
+
+    // Act
+    await user.click(saveCheckbox)
+
+    // Assert
+    expect(axios.post).toHaveBeenCalledWith(
+      PUSH_STOCK_URL,
+      { pageTitle: 'Example Page', url: 'https://example.com' },
+      { headers: { Authorization: `Bearer ${RAW_TOKEN}` } },
+    )
+  })
+
+  it('prompts to reconnect when the saved token is rejected with 401 on save', async () => {
+    // Arrange
+    ;(chrome.storage.local.get as any).mockResolvedValue({ nsx_pat: RAW_TOKEN })
+    ;(axios.post as any).mockRejectedValue({
+      isAxiosError: true,
+      response: { status: 401 },
+    })
+    stubActiveTab()
+    const user = userEvent.setup()
+    render(<App />)
+    const saveCheckbox = await screen.findByRole('checkbox')
+    await waitFor(() => expect(saveCheckbox).toBeEnabled())
+
+    // Act
+    await user.click(saveCheckbox)
+
+    // Assert — the reconnect alert and the paste panel both appear after the 401.
+    expect(
+      await screen.findByTestId('pat-reconnect-notice'),
+    ).toBeInTheDocument()
+    expect(screen.getByTestId('pat-connect-panel')).toBeInTheDocument()
+  })
+})

--- a/browser-extension/wxt.config.ts
+++ b/browser-extension/wxt.config.ts
@@ -1,17 +1,19 @@
-import { defineConfig } from 'wxt';
+import { defineConfig } from 'wxt'
 
 // https://wxt.dev/api/config.html
 export default defineConfig({
   modules: ['@wxt-dev/module-react'],
   srcDir: 'src',
   outDir: '.output',
-  
+
   manifest: {
     name: 'Reading List',
     description: 'ReadingList Browser Extension',
     permissions: ['activeTab', 'storage', 'tabs'],
-    host_permissions: ['<all_urls>'],
-    
+    // Scoped to the NSX API origins only (E15). The current tab's URL/title comes from the
+    // `activeTab`/`tabs` permissions, so cross-origin access to arbitrary sites is not needed.
+    host_permissions: ['http://localhost:4000/*', 'https://nsx.malloc.tokyo/*'],
+
     // Browser-specific manifest configuration
     action: {
       default_popup: 'popup.html',
@@ -21,11 +23,11 @@ export default defineConfig({
         '128': 'images/logo.png',
       },
     },
-    
+
     icons: {
       '16': 'images/logo.png',
       '48': 'images/logo.png',
       '128': 'images/logo.png',
     },
   },
-});
+})

--- a/prisma/migrations/20260530141710_add_personal_access_tokens/migration.sql
+++ b/prisma/migrations/20260530141710_add_personal_access_tokens/migration.sql
@@ -1,0 +1,20 @@
+-- CreateTable
+CREATE TABLE `personal_access_tokens` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `tokenHash` CHAR(64) NOT NULL,
+    `tokenSuffix` CHAR(4) NOT NULL,
+    `name` VARCHAR(255) NOT NULL,
+    `userId` INTEGER NOT NULL,
+    `lastUsedAt` DATETIME(3) NULL,
+    `expiresAt` DATETIME(3) NULL,
+    `revokedAt` DATETIME(3) NULL,
+    `createdAt` DATETIME(3) NOT NULL DEFAULT CURRENT_TIMESTAMP(3),
+    `updatedAt` DATETIME(3) NOT NULL,
+
+    UNIQUE INDEX `personal_access_tokens_tokenHash_key`(`tokenHash`),
+    INDEX `personal_access_tokens_userId_idx`(`userId`),
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AddForeignKey
+ALTER TABLE `personal_access_tokens` ADD CONSTRAINT `personal_access_tokens_userId_fkey` FOREIGN KEY (`userId`) REFERENCES `authors`(`id`) ON DELETE CASCADE ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -8,15 +8,16 @@ datasource db {
 }
 
 model User {
-  id                   Int            @id @default(autoincrement())
-  name                 String         @unique @db.VarChar(255)
-  createdAt            DateTime       @default(now())
-  password             String         @db.Text
-  sessionVersion       Int            @default(0)
-  updatedAt            DateTime       @updatedAt
-  useLegacyHoverColors Boolean        @default(false)
+  id                   Int                   @id @default(autoincrement())
+  name                 String                @unique @db.VarChar(255)
+  createdAt            DateTime              @default(now())
+  password             String                @db.Text
+  sessionVersion       Int                   @default(0)
+  updatedAt            DateTime              @updatedAt
+  useLegacyHoverColors Boolean               @default(false)
   posts                Post[]
   refreshTokens        RefreshToken[]
+  personalAccessTokens PersonalAccessToken[]
   stocks               Stock[]
   tweets               Tweet[]
 
@@ -94,4 +95,21 @@ model RefreshToken {
   @@index([userId])
   @@index([expiresAt])
   @@map("refresh_tokens")
+}
+
+model PersonalAccessToken {
+  id          Int       @id @default(autoincrement())
+  tokenHash   String    @unique @db.Char(64) // sha256 hex of "nsx_pat_<raw>"
+  tokenSuffix String    @db.Char(4) // last 4 chars of raw token, for masked list (hash can't reveal it)
+  name        String    @db.VarChar(255) // human label, e.g. "Chrome extension"
+  userId      Int
+  lastUsedAt  DateTime?
+  expiresAt   DateTime? // null = non-expiring (default for this single-scope PAT)
+  revokedAt   DateTime?
+  createdAt   DateTime  @default(now())
+  updatedAt   DateTime  @updatedAt
+  user        User      @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("personal_access_tokens")
 }

--- a/server/api.ts
+++ b/server/api.ts
@@ -3,6 +3,7 @@ import type { Router } from 'express'
 
 import blueskyRoute from './routes/bluesky'
 import healthRoute from './routes/health'
+import personalAccessTokenRoute from './routes/personalAccessToken'
 import postRoute from './routes/post'
 import stockRoute from './routes/stock'
 import translateRoute from './routes/translate'
@@ -20,6 +21,7 @@ router.use(postRoute)
 router.use(userRoute)
 // TODO: Refactor /tweet style
 router.use(stockRoute)
+router.use(personalAccessTokenRoute)
 router.use('/tweet', tweet)
 router.use(translateRoute)
 router.use(blueskyRoute)

--- a/server/auth.ts
+++ b/server/auth.ts
@@ -1,6 +1,9 @@
 import type { Request, Response, NextFunction } from 'express'
 
-import { authenticateRequestSession } from './lib/authSession'
+import {
+  authenticateRequestSession,
+  authenticateStockPatToken,
+} from './lib/authSession'
 import Logger from './lib/Logger'
 
 /**
@@ -22,6 +25,50 @@ export const isAuthorized = async (
 ): Promise<void> => {
   try {
     const session = await authenticateRequestSession(req, res)
+
+    if (!session.ok) {
+      res.status(session.status).json({ error: session.message })
+      return
+    }
+
+    req.authenticatedUser = session.user
+    return next()
+  } catch (error) {
+    Logger.error(error)
+    res.status(500).json({ error: 'Authentication failed' })
+  }
+}
+
+/**
+ * Authenticates an extension stock-write request via PAT (Bearer) or cookie session.
+ *
+ * Mounted on the extension-facing stock endpoints (`/push_stock`, `/stock/exists`).
+ * Dispatches on the `Authorization` header: absent -> the unchanged cookie-session
+ * middleware (so logged-in web requests behave exactly as before, the U7 guard);
+ * present -> a PAT-only path that never reads or clears cookies, so an invalid PAT
+ * cannot evict the owner's browser session (the U5 confused-deputy guard).
+ *
+ * @param req - Express request carrying `Authorization: Bearer nsx_pat_<raw>` or auth cookies.
+ * @param res - Express response used for authentication failures.
+ * @param next - Express continuation callback for authorized requests.
+ * @returns Nothing; either calls `next()` or completes the response.
+ * @example router.post('/push_stock', authenticateStockRequest, validateBody(schema), handler)
+ */
+export const authenticateStockRequest = async (
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  // No bearer credential -> reuse the existing cookie-session middleware verbatim,
+  // including its own cookie clearing on failure (U7 regression guard).
+  if (req.headers.authorization === undefined) {
+    return isAuthorized(req, res, next)
+  }
+
+  // Bearer present -> PAT path only. Cookie auth never runs here, so a bad PAT can
+  // never clear the owner's auth cookies (U5 confused-deputy guard).
+  try {
+    const session = await authenticateStockPatToken(req.headers.authorization)
 
     if (!session.ok) {
       res.status(session.status).json({ error: session.message })

--- a/server/lib/Logger.ts
+++ b/server/lib/Logger.ts
@@ -16,18 +16,31 @@ const REDACTED_LOG_PATHS = [
   'token',
   'accessToken',
   'refreshToken',
+  // PAT raw values must never reach logs (E5): the Bearer header arrives under the
+  // lowercased `authorization`, but defend the uppercase + PAT-specific key shapes too.
+  'Authorization',
+  'rawToken',
+  'pat',
+  'personalAccessToken',
   'headers.authorization',
+  'headers.Authorization',
   'headers.cookie',
   'req.headers.authorization',
+  'req.headers.Authorization',
   'req.headers.cookie',
   'body.password',
   'body.token',
   'body.accessToken',
   'body.refreshToken',
+  'body.rawToken',
+  'body.personalAccessToken',
   '*.password',
   '*.token',
   '*.accessToken',
   '*.refreshToken',
+  '*.rawToken',
+  '*.pat',
+  '*.personalAccessToken',
 ]
 
 /**

--- a/server/lib/authSession.ts
+++ b/server/lib/authSession.ts
@@ -403,11 +403,17 @@ export const authenticateStockPatToken = async (
   }
 
   // Best-effort last-used bookkeeping, kept as a separate write so it never widens
-  // the atomic validation query above.
-  await prisma.personalAccessToken.update({
-    where: { id: personalAccessToken.id },
-    data: { lastUsedAt: now },
-  })
+  // the atomic validation query above. Wrapped in try/catch so a transient write
+  // failure can't turn an already-successful authentication into a 500 — the PAT is
+  // valid regardless of whether we managed to stamp `lastUsedAt`.
+  try {
+    await prisma.personalAccessToken.update({
+      where: { id: personalAccessToken.id },
+      data: { lastUsedAt: now },
+    })
+  } catch (error) {
+    Logger.error(error)
+  }
 
   return { ok: true, user: personalAccessToken.user }
 }

--- a/server/lib/authSession.ts
+++ b/server/lib/authSession.ts
@@ -36,16 +36,16 @@ const SESSION_USER_SELECT = {
 } as const
 
 /**
- * Hashes a refresh token before it is stored or looked up.
+ * Hashes a bearer credential (refresh token or PAT) before it is stored or looked up.
  *
- * Called by refresh-token persistence so raw bearer credentials never live in
- * the database.
+ * Shared by refresh-token persistence and personal-access-token mint/verify so raw
+ * credentials never live in the database; both store and compare on the digest only.
  *
- * @param token - Raw refresh token cookie value.
+ * @param token - Raw bearer credential (refresh-token cookie value or `nsx_pat_<raw>`).
  * @returns SHA-256 hex digest of the token.
- * @example hashRefreshToken(refreshToken)
+ * @example hashToken(refreshToken)
  */
-const hashRefreshToken = (token: string): string => {
+export const hashToken = (token: string): string => {
   return createHash('sha256').update(token).digest('hex')
 }
 
@@ -140,7 +140,7 @@ const storeRefreshToken = async (
 ): Promise<void> => {
   await prisma.refreshToken.create({
     data: {
-      tokenHash: hashRefreshToken(refreshToken),
+      tokenHash: hashToken(refreshToken),
       userId,
       expiresAt: getTokenExpiration(refreshToken),
     },
@@ -163,7 +163,7 @@ export const revokeRefreshToken = async (
 
   await prisma.refreshToken.updateMany({
     where: {
-      tokenHash: hashRefreshToken(refreshToken),
+      tokenHash: hashToken(refreshToken),
       revokedAt: null,
     },
     data: { revokedAt: new Date() },
@@ -219,7 +219,7 @@ const rotateRefreshSession = async (
   if (!refreshToken) return null
 
   const decoded = verifyRefreshToken(refreshToken)
-  const tokenHash = hashRefreshToken(refreshToken)
+  const tokenHash = hashToken(refreshToken)
   const user = await findUserForTokenPayload(decoded)
   if (!user) {
     await revokeRefreshToken(refreshToken)
@@ -240,7 +240,7 @@ const rotateRefreshSession = async (
 
     await tx.refreshToken.create({
       data: {
-        tokenHash: hashRefreshToken(nextRefreshToken),
+        tokenHash: hashToken(nextRefreshToken),
         userId: user.id,
         expiresAt: getTokenExpiration(nextRefreshToken),
       },
@@ -330,4 +330,84 @@ export const authenticateRequestSession = async (
         ? 'Invalid or expired token'
         : 'No token found',
   }
+}
+
+/**
+ * Extracts the raw bearer token from an `Authorization` header value.
+ *
+ * Called by PAT stock-write auth before hashing, so a missing or malformed header
+ * fails closed as unauthenticated (401) instead of throwing (500) — the U6 guard.
+ *
+ * @param authorizationHeader - Raw `Authorization` header (`Bearer <token>`) or undefined.
+ * @returns
+ * - The trimmed token when the header is a non-empty `Bearer <token>`
+ * - null when the header is missing, not a Bearer scheme, or carries an empty token
+ * @example
+ * extractBearerToken('Bearer nsx_pat_abc') // => 'nsx_pat_abc'
+ * extractBearerToken('Basic xyz')          // => null
+ */
+const extractBearerToken = (
+  authorizationHeader: string | undefined,
+): string | null => {
+  if (typeof authorizationHeader !== 'string') return null
+
+  const bearerMatch = authorizationHeader.match(/^Bearer (.+)$/)
+  if (!bearerMatch) return null
+
+  const rawToken = bearerMatch[1].trim()
+  return rawToken.length > 0 ? rawToken : null
+}
+
+/**
+ * Authenticates a stock-write request that presents a Personal Access Token.
+ *
+ * Called by the `authenticateStockRequest` middleware whenever an `Authorization`
+ * header is present. Validates the PAT in a single atomic query (not revoked, not
+ * expired) and hydrates the full session user in the same round-trip. It NEVER reads
+ * or clears auth cookies, so an invalid PAT cannot evict the owner's browser session
+ * (the U5 confused-deputy guard).
+ *
+ * @param authorizationHeader - Raw `Authorization` header value (`Bearer nsx_pat_<raw>`).
+ * @returns
+ * - `{ ok: true, user }` with the fully-hydrated owner when the PAT is valid
+ * - `{ ok: false, status: 401, message }` when the header is malformed, or the PAT is
+ *   unknown, revoked, or expired
+ * @example await authenticateStockPatToken(req.headers.authorization)
+ */
+export const authenticateStockPatToken = async (
+  authorizationHeader: string | undefined,
+): Promise<AuthSessionResult> => {
+  const rawToken = extractBearerToken(authorizationHeader)
+  if (!rawToken) {
+    return {
+      ok: false,
+      status: 401,
+      message: 'Invalid or missing access token',
+    }
+  }
+
+  const now = new Date()
+  // Single atomic validity check: unknown / revoked / expired all collapse to
+  // "no row" -> 401. The owner is hydrated in the same query (E4 full session user).
+  const personalAccessToken = await prisma.personalAccessToken.findFirst({
+    where: {
+      tokenHash: hashToken(rawToken),
+      revokedAt: null,
+      OR: [{ expiresAt: null }, { expiresAt: { gt: now } }],
+    },
+    select: { id: true, user: { select: SESSION_USER_SELECT } },
+  })
+
+  if (!personalAccessToken) {
+    return { ok: false, status: 401, message: 'Invalid or expired token' }
+  }
+
+  // Best-effort last-used bookkeeping, kept as a separate write so it never widens
+  // the atomic validation query above.
+  await prisma.personalAccessToken.update({
+    where: { id: personalAccessToken.id },
+    data: { lastUsedAt: now },
+  })
+
+  return { ok: true, user: personalAccessToken.user }
 }

--- a/server/lib/authSession.ts
+++ b/server/lib/authSession.ts
@@ -351,7 +351,9 @@ const extractBearerToken = (
 ): string | null => {
   if (typeof authorizationHeader !== 'string') return null
 
-  const bearerMatch = authorizationHeader.match(/^Bearer (.+)$/)
+  // Case-insensitive scheme + flexible whitespace per RFC 7235 (auth-scheme is
+  // case-insensitive), so 'bearer nsx_pat_...' and extra spaces still parse.
+  const bearerMatch = authorizationHeader.match(/^Bearer\s+(.+)$/i)
   if (!bearerMatch) return null
 
   const rawToken = bearerMatch[1].trim()

--- a/server/lib/authenticateStockRequest.contract.test.ts
+++ b/server/lib/authenticateStockRequest.contract.test.ts
@@ -1,47 +1,212 @@
-import { describe, it } from 'vitest'
+import type { Request, Response, NextFunction } from 'express'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { authenticateStockRequest } from '../auth'
+import { prisma } from '../prisma'
+
+import { hashToken } from './authSession'
+
+// DB-free: prisma is fully mocked so the server vitest project stays in Node with no
+// DATABASE_URL. vitest hoists this vi.mock above the imports, so `prisma` here and the
+// client reached transitively through `../auth` are both the mock. We assert behavior
+// (dispatch, hydrate, no-cookie-clear); the real WHERE clause runs against MySQL at E2E.
+vi.mock('../prisma', () => ({
+  prisma: {
+    personalAccessToken: { findFirst: vi.fn(), update: vi.fn() },
+    user: { findFirst: vi.fn() },
+    refreshToken: { updateMany: vi.fn(), create: vi.fn() },
+  },
+}))
+
+const findPatMock = vi.mocked(prisma.personalAccessToken.findFirst)
+const updatePatMock = vi.mocked(prisma.personalAccessToken.update)
+
+// A 64-hex-char body → a well-formed `nsx_pat_<64hex>` token.
+const VALID_RAW_TOKEN = `nsx_pat_${'abcd1234'.repeat(8)}`
+
+// The full session-user shape the cookie branch hydrates (SESSION_USER_SELECT).
+const FULL_SESSION_USER = {
+  id: 7,
+  name: 'Raphtalia',
+  password: 'hashed-password',
+  sessionVersion: 3,
+  createdAt: new Date('2026-01-01T00:00:00.000Z'),
+  updatedAt: new Date('2026-02-01T00:00:00.000Z'),
+  useLegacyHoverColors: false,
+}
 
 /**
- * Contract placeholder for the scoped-PAT stock-write middleware.
- *
- * Exists so the regression guards for `authenticateStockRequest` (the dedicated
- * middleware introduced in PR2 / #3784) are captured in the test tree before the
- * implementation lands. Each `it.todo` names an observable behavior the middleware
- * MUST satisfy; PR2 replaces every `it.todo` with a real DB-backed assertion
- * (U5–U8 in eng-review-test-plan-20260528-104950.md). The server vitest project
- * collects this file in the Node environment (see vitest.config.ts).
- *
- * Kept import-free of the middleware itself because that symbol does not exist
- * until PR2 — adding the import now would break collection in PR1.
+ * Builds an Express response double whose chainable methods are spies.
+ * @returns A response with `status`/`json`/`cookie` as chainable `vi.fn()`s.
+ * @example const res = buildResponse(); expect(res.status).toHaveBeenCalledWith(401)
  */
-describe('authenticateStockRequest contract (filled in by PR2 / #3784)', () => {
-  // Happy path: a valid Bearer PAT authorizes a stock write without a cookie session.
-  it.todo('authenticates a stock write when a valid Bearer PAT is supplied')
+const buildResponse = (): Response => {
+  const res = {} as Response
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  res.cookie = vi.fn().mockReturnValue(res)
+  return res
+}
 
-  // E4: the PAT branch must hydrate the same full user shape the cookie branch does.
-  it.todo(
-    'hydrates req.authenticatedUser with the full session-user shape for a PAT request',
-  )
+/**
+ * Builds an Express request double with the given Authorization header + cookies.
+ * @param authorization - Raw `Authorization` header value, or undefined to omit it.
+ * @param cookies - Cookie jar to expose at `req.cookies` (defaults to empty).
+ * @returns A request shaped enough for the stock-write middleware.
+ * @example buildRequest(`Bearer ${VALID_RAW_TOKEN}`)
+ */
+const buildRequest = (
+  authorization: string | undefined,
+  cookies: Record<string, string> = {},
+): Request =>
+  ({
+    headers: authorization === undefined ? {} : { authorization },
+    cookies,
+  }) as unknown as Request
 
-  // E14: revoked / expired tokens are filtered inside one atomic lookup, not in JS.
-  it.todo(
-    'validates the PAT in a single atomic query that excludes revoked and expired tokens',
-  )
+beforeEach(() => {
+  vi.clearAllMocks()
+})
 
-  // U8: successful PAT auth records lastUsedAt for owner visibility.
-  it.todo('updates lastUsedAt after a successful PAT authentication')
+describe('authenticateStockRequest', () => {
+  it('authenticates a stock write when a valid Bearer PAT is supplied', async () => {
+    // Arrange
+    findPatMock.mockResolvedValue({ id: 11, user: FULL_SESSION_USER } as never)
+    updatePatMock.mockResolvedValue({} as never)
+    const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`)
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
 
-  // U7: absent Authorization header leaves the existing cookie-session path untouched.
-  it.todo(
-    'falls back to the existing cookie session when no Authorization header is present',
-  )
+    // Act
+    await authenticateStockRequest(req, res, next)
 
-  // U5 (confused-deputy guard): an invalid/revoked Bearer PAT must NOT clear the owner's auth cookies.
-  it.todo(
-    'responds 401 without clearing auth cookies when the Bearer PAT is invalid or revoked',
-  )
+    // Assert
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+  })
 
-  // U6: a malformed Authorization header is a client error (401), never a server error (500).
-  it.todo(
-    'responds 401 rather than 500 when the Authorization header is malformed',
-  )
+  it('hydrates req.authenticatedUser with the full session-user shape for a PAT request', async () => {
+    // Arrange
+    findPatMock.mockResolvedValue({ id: 11, user: FULL_SESSION_USER } as never)
+    updatePatMock.mockResolvedValue({} as never)
+    const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`)
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert
+    expect(req.authenticatedUser).toEqual({
+      id: 7,
+      name: 'Raphtalia',
+      password: 'hashed-password',
+      sessionVersion: 3,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+      updatedAt: new Date('2026-02-01T00:00:00.000Z'),
+      useLegacyHoverColors: false,
+    })
+  })
+
+  it('validates the PAT in a single atomic query that excludes revoked and expired tokens', async () => {
+    // Arrange
+    findPatMock.mockResolvedValue({ id: 11, user: FULL_SESSION_USER } as never)
+    updatePatMock.mockResolvedValue({} as never)
+    const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`)
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert
+    expect(findPatMock).toHaveBeenCalledOnce()
+    const findArgs = findPatMock.mock.calls[0][0] as {
+      where: {
+        tokenHash: string
+        revokedAt: null
+        OR: Array<{ expiresAt: null | { gt: Date } }>
+      }
+      select: { user: unknown }
+    }
+    expect(findArgs.where.tokenHash).toBe(hashToken(VALID_RAW_TOKEN))
+    expect(findArgs.where.revokedAt).toBeNull()
+    expect(findArgs.where.OR).toEqual([
+      { expiresAt: null },
+      { expiresAt: { gt: expect.any(Date) } },
+    ])
+    expect(findArgs.select.user).toBeTruthy()
+  })
+
+  it('updates lastUsedAt after a successful PAT authentication', async () => {
+    // Arrange
+    findPatMock.mockResolvedValue({ id: 11, user: FULL_SESSION_USER } as never)
+    updatePatMock.mockResolvedValue({} as never)
+    const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`)
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert
+    expect(updatePatMock).toHaveBeenCalledOnce()
+    const updateArgs = updatePatMock.mock.calls[0][0] as {
+      where: { id: number }
+      data: { lastUsedAt: Date }
+    }
+    expect(updateArgs.where).toEqual({ id: 11 })
+    expect(updateArgs.data.lastUsedAt).toBeInstanceOf(Date)
+  })
+
+  it('falls back to the existing cookie session when no Authorization header is present', async () => {
+    // Arrange — no Authorization header and no auth cookies.
+    const req = buildRequest(undefined, {})
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert — the cookie path ran (its "No token found" 401), never the PAT lookup.
+    expect(findPatMock).not.toHaveBeenCalled()
+    expect(next).not.toHaveBeenCalled()
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(res.json).toHaveBeenCalledWith({ error: 'No token found' })
+  })
+
+  it('responds 401 without clearing auth cookies when the Bearer PAT is invalid or revoked', async () => {
+    // Arrange — a Bearer PAT that matches no active row, alongside live auth cookies.
+    findPatMock.mockResolvedValue(null as never)
+    const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`, {
+      accessToken: 'owner-access-cookie',
+      refreshToken: 'owner-refresh-cookie',
+    })
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert — 401, and the owner's cookies are left untouched (confused-deputy guard).
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(next).not.toHaveBeenCalled()
+    expect(res.cookie).not.toHaveBeenCalled()
+  })
+
+  it('responds 401 rather than 500 when the Authorization header is malformed', async () => {
+    // Arrange — a header that is present but not a usable Bearer token.
+    const req = buildRequest('NotBearer whatever')
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert — client error, never a server error, and no DB lookup is attempted.
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(res.status).not.toHaveBeenCalledWith(500)
+    expect(findPatMock).not.toHaveBeenCalled()
+    expect(res.cookie).not.toHaveBeenCalled()
+  })
 })

--- a/server/lib/authenticateStockRequest.contract.test.ts
+++ b/server/lib/authenticateStockRequest.contract.test.ts
@@ -159,6 +159,24 @@ describe('authenticateStockRequest', () => {
     expect(updateArgs.data.lastUsedAt).toBeInstanceOf(Date)
   })
 
+  it('still authenticates the request when the best-effort lastUsedAt write fails', async () => {
+    // Arrange — the PAT is valid, but the post-auth lastUsedAt bookkeeping write
+    // throws (transient DB hiccup). Authentication already succeeded, so the request
+    // must still pass through instead of collapsing into a 500.
+    findPatMock.mockResolvedValue({ id: 11, user: FULL_SESSION_USER } as never)
+    updatePatMock.mockRejectedValue(new Error('transient write failure'))
+    const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`)
+    const res = buildResponse()
+    const next = vi.fn() as NextFunction
+
+    // Act
+    await authenticateStockRequest(req, res, next)
+
+    // Assert — request proceeds; a post-auth bookkeeping failure never surfaces as 500.
+    expect(next).toHaveBeenCalledOnce()
+    expect(res.status).not.toHaveBeenCalled()
+  })
+
   it('falls back to the existing cookie session when no Authorization header is present', async () => {
     // Arrange — no Authorization header and no auth cookies.
     const req = buildRequest(undefined, {})

--- a/server/lib/requestSchemas.ts
+++ b/server/lib/requestSchemas.ts
@@ -3,6 +3,7 @@ import { z } from 'zod'
 const POST_TITLE_MAX_LENGTH = 400
 const POST_BODY_MAX_LENGTH = 50_000
 const PROFILE_NAME_MAX_LENGTH = 255
+const PAT_NAME_MAX_LENGTH = 255
 const STOCK_TITLE_MAX_LENGTH = 1_000
 const STOCK_URL_MAX_LENGTH = 2_048
 const LANGUAGE_CODE_MAX_LENGTH = 16
@@ -102,6 +103,12 @@ export const pushStockBodySchema = z
     path: ['pageTitle'],
   })
 
+export const mintPersonalAccessTokenBodySchema = z
+  .object({
+    name: requiredText('Token name', PAT_NAME_MAX_LENGTH),
+  })
+  .strict()
+
 export const createTweetBodySchema = z
   .object({
     text: requiredText('Tweet text', TWEET_TEXT_MAX_LENGTH),
@@ -131,6 +138,9 @@ export type HoverColorPreferenceBody = z.output<
   typeof hoverColorPreferenceBodySchema
 >
 export type PushStockBody = z.output<typeof pushStockBodySchema>
+export type MintPersonalAccessTokenBody = z.output<
+  typeof mintPersonalAccessTokenBodySchema
+>
 export type CreateTweetBody = z.output<typeof createTweetBodySchema>
 export type TranslateBody = z.output<typeof translateBodySchema>
 export type BlueskyPostBody = z.output<typeof blueskyPostBodySchema>

--- a/server/routes/personalAccessToken.test.ts
+++ b/server/routes/personalAccessToken.test.ts
@@ -197,4 +197,21 @@ describe('revokePersonalAccessTokenHandler', () => {
     expect(res.json).toHaveBeenCalledWith({ id: 5, revokedAt })
     expect(updateMock).not.toHaveBeenCalled()
   })
+
+  it('rejects a non-numeric id with trailing characters as 400 before any DB lookup', async () => {
+    // Arrange — "5abc" would parse to 5 under Number.parseInt; the guard must reject it.
+    const req = {
+      authenticatedUser: { id: OWNER_ID },
+      params: { id: '5abc' },
+    } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await revokePersonalAccessTokenHandler(req, res)
+
+    // Assert — 400, and the malformed id never reaches the database.
+    expect(res.status).toHaveBeenCalledWith(400)
+    expect(findFirstMock).not.toHaveBeenCalled()
+    expect(updateMock).not.toHaveBeenCalled()
+  })
 })

--- a/server/routes/personalAccessToken.test.ts
+++ b/server/routes/personalAccessToken.test.ts
@@ -1,0 +1,200 @@
+import type { Request, Response } from 'express'
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+import { hashToken } from '../lib/authSession'
+import { prisma } from '../prisma'
+
+import {
+  mintPersonalAccessTokenHandler,
+  listPersonalAccessTokensHandler,
+  revokePersonalAccessTokenHandler,
+} from './personalAccessToken'
+
+// DB-free: prisma is mocked so the server vitest project stays in Node (no DATABASE_URL).
+// vitest hoists this vi.mock above the imports, so `prisma` above is the mock.
+vi.mock('../prisma', () => ({
+  prisma: {
+    personalAccessToken: {
+      create: vi.fn(),
+      findMany: vi.fn(),
+      findFirst: vi.fn(),
+      update: vi.fn(),
+    },
+  },
+}))
+
+const createMock = vi.mocked(prisma.personalAccessToken.create)
+const findManyMock = vi.mocked(prisma.personalAccessToken.findMany)
+const findFirstMock = vi.mocked(prisma.personalAccessToken.findFirst)
+const updateMock = vi.mocked(prisma.personalAccessToken.update)
+
+const OWNER_ID = 7
+
+/**
+ * Builds an Express response double whose chainable methods are spies.
+ * @returns A response with `status`/`json` as chainable `vi.fn()`s.
+ * @example const res = buildResponse(); expect(res.status).toHaveBeenCalledWith(201)
+ */
+const buildResponse = (): Response => {
+  const res = {} as Response
+  res.status = vi.fn().mockReturnValue(res)
+  res.json = vi.fn().mockReturnValue(res)
+  return res
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+})
+
+describe('mintPersonalAccessTokenHandler', () => {
+  it('returns a freshly generated raw token once and stores only its hash', async () => {
+    // Arrange
+    createMock.mockResolvedValue({
+      id: 1,
+      name: 'Chrome extension',
+      tokenSuffix: '0000',
+      createdAt: new Date('2026-05-30T00:00:00.000Z'),
+    } as never)
+    const req = {
+      authenticatedUser: { id: OWNER_ID },
+      body: { name: 'Chrome extension' },
+    } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await mintPersonalAccessTokenHandler(req, res)
+
+    // Assert — 201 with a raw token, and the persisted row holds the hash, never the raw value.
+    expect(res.status).toHaveBeenCalledWith(201)
+    const responseBody = vi.mocked(res.json).mock.calls[0][0] as {
+      token: string
+      tokenHash?: string
+    }
+    expect(responseBody.token).toMatch(/^nsx_pat_[0-9a-f]{64}$/)
+    expect(responseBody).not.toHaveProperty('tokenHash')
+
+    const createArgs = createMock.mock.calls[0][0] as {
+      data: { tokenHash: string; tokenSuffix: string; userId: number }
+    }
+    expect(createArgs.data.tokenHash).toBe(hashToken(responseBody.token))
+    expect(createArgs.data.tokenHash).not.toBe(responseBody.token)
+    expect(createArgs.data.tokenSuffix).toBe(responseBody.token.slice(-4))
+    expect(createArgs.data.userId).toBe(OWNER_ID)
+  })
+
+  it('responds 401 when there is no authenticated session', async () => {
+    // Arrange
+    const req = { body: { name: 'x' } } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await mintPersonalAccessTokenHandler(req, res)
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(401)
+    expect(createMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('listPersonalAccessTokensHandler', () => {
+  it('returns the masked token list without ever selecting the hash', async () => {
+    // Arrange
+    findManyMock.mockResolvedValue([
+      {
+        id: 1,
+        name: 'Chrome extension',
+        tokenSuffix: 'abcd',
+        createdAt: new Date('2026-05-30T00:00:00.000Z'),
+        lastUsedAt: null,
+        revokedAt: null,
+      },
+    ] as never)
+    const req = { authenticatedUser: { id: OWNER_ID } } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await listPersonalAccessTokensHandler(req, res)
+
+    // Assert — owner-scoped query that selects the suffix but never the hash/raw value.
+    expect(res.status).toHaveBeenCalledWith(200)
+    const findManyArgs = findManyMock.mock.calls[0][0] as {
+      where: { userId: number }
+      select: Record<string, boolean>
+    }
+    expect(findManyArgs.where).toEqual({ userId: OWNER_ID })
+    expect(findManyArgs.select.tokenSuffix).toBe(true)
+    expect(findManyArgs.select).not.toHaveProperty('tokenHash')
+
+    const responseBody = vi.mocked(res.json).mock.calls[0][0] as {
+      tokens: Array<Record<string, unknown>>
+    }
+    expect(responseBody.tokens[0]).not.toHaveProperty('tokenHash')
+  })
+})
+
+describe('revokePersonalAccessTokenHandler', () => {
+  it('sets revokedAt and returns it for an owned, active token', async () => {
+    // Arrange
+    findFirstMock.mockResolvedValue({ id: 5, revokedAt: null } as never)
+    const revokedAt = new Date('2026-05-30T12:00:00.000Z')
+    updateMock.mockResolvedValue({ id: 5, revokedAt } as never)
+    const req = {
+      authenticatedUser: { id: OWNER_ID },
+      params: { id: '5' },
+    } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await revokePersonalAccessTokenHandler(req, res)
+
+    // Assert — owner-scoped lookup, then a single revoking update.
+    expect(findFirstMock).toHaveBeenCalledWith({
+      where: { id: 5, userId: OWNER_ID },
+      select: { id: true, revokedAt: true },
+    })
+    const updateArgs = updateMock.mock.calls[0][0] as {
+      where: { id: number }
+      data: { revokedAt: Date }
+    }
+    expect(updateArgs.where).toEqual({ id: 5 })
+    expect(updateArgs.data.revokedAt).toBeInstanceOf(Date)
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ id: 5, revokedAt })
+  })
+
+  it('responds 404 for a token that is unknown or owned by someone else', async () => {
+    // Arrange
+    findFirstMock.mockResolvedValue(null as never)
+    const req = {
+      authenticatedUser: { id: OWNER_ID },
+      params: { id: '999' },
+    } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await revokePersonalAccessTokenHandler(req, res)
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(404)
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+
+  it('is idempotent: re-revoking returns the existing timestamp without a second write', async () => {
+    // Arrange
+    const revokedAt = new Date('2026-05-01T00:00:00.000Z')
+    findFirstMock.mockResolvedValue({ id: 5, revokedAt } as never)
+    const req = {
+      authenticatedUser: { id: OWNER_ID },
+      params: { id: '5' },
+    } as unknown as Request
+    const res = buildResponse()
+
+    // Act
+    await revokePersonalAccessTokenHandler(req, res)
+
+    // Assert
+    expect(res.status).toHaveBeenCalledWith(200)
+    expect(res.json).toHaveBeenCalledWith({ id: 5, revokedAt })
+    expect(updateMock).not.toHaveBeenCalled()
+  })
+})

--- a/server/routes/personalAccessToken.ts
+++ b/server/routes/personalAccessToken.ts
@@ -174,11 +174,14 @@ export const revokePersonalAccessTokenHandler = async (
       return
     }
 
-    const tokenId = Number.parseInt(String(req.params.id), 10)
-    if (!Number.isInteger(tokenId)) {
+    // Require a purely-numeric id. Number.parseInt('5abc', 10) === 5 would silently
+    // treat a malformed id as token 5, contradicting the 400-for-non-numeric contract.
+    const rawTokenId = String(req.params.id)
+    if (!/^\d+$/.test(rawTokenId)) {
       res.status(400).json({ error: INVALID_TOKEN_ID_MESSAGE })
       return
     }
+    const tokenId = Number.parseInt(rawTokenId, 10)
 
     // Ownership check is scoped by userId so one account can't revoke another's token.
     const existing = await prisma.personalAccessToken.findFirst({

--- a/server/routes/personalAccessToken.ts
+++ b/server/routes/personalAccessToken.ts
@@ -1,0 +1,236 @@
+import { randomBytes } from 'node:crypto'
+
+import type { Request, Response, Router, RequestHandler } from 'express'
+import express from 'express'
+import rateLimit from 'express-rate-limit'
+
+import { isAuthorized } from '../auth'
+import { hashToken } from '../lib/authSession'
+import Logger from '../lib/Logger'
+import {
+  mintPersonalAccessTokenBodySchema,
+  type MintPersonalAccessTokenBody,
+} from '../lib/requestSchemas'
+import { validateBody } from '../lib/validateRequest'
+import { prisma } from '../prisma'
+
+const router: Router = express.Router()
+
+const NO_TOKEN_MESSAGE = 'No token found'
+const INTERNAL_SERVER_ERROR_MESSAGE = 'Internal Server Error'
+const TOKEN_NOT_FOUND_MESSAGE = 'Token not found'
+const INVALID_TOKEN_ID_MESSAGE = 'Invalid token id'
+
+const PAT_TOKEN_PREFIX = 'nsx_pat_'
+const PAT_RANDOM_BYTES = 32
+const PAT_SUFFIX_LENGTH = 4
+const MINT_WINDOW_MS = 60 * 60 * 1000
+const MINT_MAX_PER_WINDOW = 10
+const isProd = process.env.NODE_ENV === 'production'
+
+// Mirror the login limiter: enforce in production, pass through elsewhere so unit
+// tests and local dev are not throttled. Caps token minting to 10 requests / hour.
+const mintLimiter: RequestHandler = isProd
+  ? rateLimit({
+      windowMs: MINT_WINDOW_MS,
+      max: MINT_MAX_PER_WINDOW,
+      standardHeaders: true,
+      legacyHeaders: false,
+      message: {
+        error: 'Too many token requests, please try again after an hour.',
+      },
+    })
+  : (_req, _res, next) => next()
+
+/**
+ * Generates a fresh raw Personal Access Token string.
+ *
+ * Called once per mint request; only the hash of this value is persisted, so the
+ * raw string returned here is the single copy the owner ever sees.
+ *
+ * @returns A `nsx_pat_<64 hex>` token carrying 256 bits of entropy.
+ * @example generateRawPatToken() // => 'nsx_pat_3f9a…'
+ */
+const generateRawPatToken = (): string =>
+  `${PAT_TOKEN_PREFIX}${randomBytes(PAT_RANDOM_BYTES).toString('hex')}`
+
+/**
+ * Mints a new PAT for the cookie-authenticated owner (E7).
+ *
+ * Mounted on `POST /api/personal_access_token`. The raw token is returned in the 201
+ * body exactly once; only its SHA-256 hash and last-4 suffix are persisted, so it can
+ * never be recovered from the database afterwards.
+ *
+ * @param req - Express request; `req.authenticatedUser` is set by `isAuthorized`.
+ * @param res - Express response.
+ * @returns
+ * - 201 `{ id, name, tokenSuffix, createdAt, token }` on success
+ * - 401 when the cookie session is missing; 500 on unexpected failure
+ * @example router.post('/personal_access_token', …, mintPersonalAccessTokenHandler)
+ */
+export const mintPersonalAccessTokenHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const userId = req.authenticatedUser?.id
+
+    if (!userId) {
+      res.status(401).json({ error: NO_TOKEN_MESSAGE })
+      return
+    }
+
+    const body = req.body as MintPersonalAccessTokenBody
+    const rawToken = generateRawPatToken()
+
+    const created = await prisma.personalAccessToken.create({
+      data: {
+        tokenHash: hashToken(rawToken),
+        tokenSuffix: rawToken.slice(-PAT_SUFFIX_LENGTH),
+        name: body.name,
+        userId,
+      },
+      select: { id: true, name: true, tokenSuffix: true, createdAt: true },
+    })
+
+    // `token` is disclosed only here; subsequent reads expose `tokenSuffix` only.
+    res.status(201).json({ ...created, token: rawToken })
+  } catch (error) {
+    Logger.error(error)
+    res.status(500).json({ error: INTERNAL_SERVER_ERROR_MESSAGE })
+  }
+}
+
+/**
+ * Lists the owner's PATs for the Settings UI (masked).
+ *
+ * Mounted on `GET /api/personal_access_token/list`. The select never includes
+ * `tokenHash` or any raw value, so the masked `nsx_pat_…<suffix>` list cannot leak a
+ * usable credential.
+ *
+ * @param req - Express request; `req.authenticatedUser` is set by `isAuthorized`.
+ * @param res - Express response.
+ * @returns
+ * - 200 `{ tokens: [{ id, name, tokenSuffix, createdAt, lastUsedAt, revokedAt }] }`
+ * - 401 when the cookie session is missing; 500 on unexpected failure
+ * @example router.get('/personal_access_token/list', …, listPersonalAccessTokensHandler)
+ */
+export const listPersonalAccessTokensHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const userId = req.authenticatedUser?.id
+
+    if (!userId) {
+      res.status(401).json({ error: NO_TOKEN_MESSAGE })
+      return
+    }
+
+    const tokens = await prisma.personalAccessToken.findMany({
+      where: { userId },
+      select: {
+        id: true,
+        name: true,
+        tokenSuffix: true,
+        createdAt: true,
+        lastUsedAt: true,
+        revokedAt: true,
+      },
+      orderBy: { createdAt: 'desc' },
+    })
+
+    res.status(200).json({ tokens })
+  } catch (error) {
+    Logger.error(error)
+    res.status(500).json({ error: INTERNAL_SERVER_ERROR_MESSAGE })
+  }
+}
+
+/**
+ * Revokes one of the owner's PATs (E7), idempotently.
+ *
+ * Mounted on `DELETE /api/personal_access_token/:id`. Sets `revokedAt` so the PAT
+ * stops authenticating. Scoped to the owner so one account cannot revoke another's
+ * token, and idempotent — re-revoking returns the existing timestamp.
+ *
+ * @param req - Express request; `req.authenticatedUser` is set by `isAuthorized`.
+ * @param res - Express response.
+ * @returns
+ * - 200 `{ id, revokedAt }` when revoked (or already revoked)
+ * - 400 for a non-numeric id; 404 when the token is unknown / not owned
+ * - 401 when the cookie session is missing; 500 on unexpected failure
+ * @example router.delete('/personal_access_token/:id', …, revokePersonalAccessTokenHandler)
+ */
+export const revokePersonalAccessTokenHandler = async (
+  req: Request,
+  res: Response,
+): Promise<void> => {
+  try {
+    const userId = req.authenticatedUser?.id
+
+    if (!userId) {
+      res.status(401).json({ error: NO_TOKEN_MESSAGE })
+      return
+    }
+
+    const tokenId = Number.parseInt(String(req.params.id), 10)
+    if (!Number.isInteger(tokenId)) {
+      res.status(400).json({ error: INVALID_TOKEN_ID_MESSAGE })
+      return
+    }
+
+    // Ownership check is scoped by userId so one account can't revoke another's token.
+    const existing = await prisma.personalAccessToken.findFirst({
+      where: { id: tokenId, userId },
+      select: { id: true, revokedAt: true },
+    })
+
+    if (!existing) {
+      res.status(404).json({ error: TOKEN_NOT_FOUND_MESSAGE })
+      return
+    }
+
+    // Already revoked → return the existing timestamp (idempotent revoke).
+    if (existing.revokedAt) {
+      res.status(200).json({ id: existing.id, revokedAt: existing.revokedAt })
+      return
+    }
+
+    const revoked = await prisma.personalAccessToken.update({
+      where: { id: tokenId },
+      data: { revokedAt: new Date() },
+      select: { id: true, revokedAt: true },
+    })
+
+    res.status(200).json(revoked)
+  } catch (error) {
+    Logger.error(error)
+    res.status(500).json({ error: INTERNAL_SERVER_ERROR_MESSAGE })
+  }
+}
+
+// Mint: cookie-authenticated, rate-limited, body-validated.
+router.post(
+  '/personal_access_token',
+  mintLimiter,
+  isAuthorized,
+  validateBody(mintPersonalAccessTokenBodySchema),
+  mintPersonalAccessTokenHandler,
+)
+
+// List: cookie-authenticated; never discloses the hash/raw value.
+router.get(
+  '/personal_access_token/list',
+  isAuthorized,
+  listPersonalAccessTokensHandler,
+)
+
+// Revoke: cookie-authenticated; owner-scoped + idempotent.
+router.delete(
+  '/personal_access_token/:id',
+  isAuthorized,
+  revokePersonalAccessTokenHandler,
+)
+
+export default router

--- a/server/routes/stock.ts
+++ b/server/routes/stock.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction, Router } from 'express'
 import express from 'express'
 
-import { isAuthorized } from '../auth'
+import { authenticateStockRequest, isAuthorized } from '../auth'
 import Logger from '../lib/Logger'
 import { pushStockBodySchema, type PushStockBody } from '../lib/requestSchemas'
 import { validateBody } from '../lib/validateRequest'
@@ -104,7 +104,8 @@ const getStockOwnershipStatus = async (
 
 router.post(
   '/push_stock',
-  isAuthorized,
+  // PAT (extension) or cookie (web) auth; validateBody stays second (E8).
+  authenticateStockRequest,
   validateBody(pushStockBodySchema),
   async (req: Request, res: Response, next: NextFunction) => {
     const body = req.body as PushStockBody
@@ -173,30 +174,35 @@ router.get('/stocklist', isAuthorized, async (req, res) => {
   }
 })
 
-router.get('/stock/exists', isAuthorized, async (req, res, next) => {
-  const normalizedUrl = normalizeStockUrl(req.query.url)
-  const userId = req.authenticatedUser?.id
+// PAT-accepting so the popup's on-open duplicate check reaches "connected" (E9).
+router.get(
+  '/stock/exists',
+  authenticateStockRequest,
+  async (req, res, next) => {
+    const normalizedUrl = normalizeStockUrl(req.query.url)
+    const userId = req.authenticatedUser?.id
 
-  if (!userId) {
-    res.status(401).json({ error: 'No token found' })
-    return
-  }
-
-  try {
-    // The popup needs a concrete URL to answer whether this page is already saved.
-    if (!normalizedUrl) {
-      res.status(400).json({ error: URL_REQUIRED_MESSAGE })
+    if (!userId) {
+      res.status(401).json({ error: 'No token found' })
       return
     }
 
-    res
-      .status(200)
-      .json({ exists: await stockUrlExists(normalizedUrl, userId) })
-  } catch (error) {
-    Logger.error(error)
-    next(error)
-  }
-})
+    try {
+      // The popup needs a concrete URL to answer whether this page is already saved.
+      if (!normalizedUrl) {
+        res.status(400).json({ error: URL_REQUIRED_MESSAGE })
+        return
+      }
+
+      res
+        .status(200)
+        .json({ exists: await stockUrlExists(normalizedUrl, userId) })
+    } catch (error) {
+      Logger.error(error)
+      next(error)
+    }
+  },
+)
 
 router.delete('/stock/:id', isAuthorized, async (req, res) => {
   try {

--- a/src/pages/Dashboard/Setting/ExtensionToken.test.tsx
+++ b/src/pages/Dashboard/Setting/ExtensionToken.test.tsx
@@ -1,0 +1,146 @@
+import { screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+
+import TestRenderer from '@/src/lib/TestRenderer'
+import { API } from '@/src/redux/API'
+import { store } from '@/src/redux/store'
+
+import { server } from '../../../../mocks/server'
+
+import ExtensionToken from './ExtensionToken'
+
+const RAW_TOKEN = `nsx_pat_${'a'.repeat(64)}`
+
+const LIST_URL = 'http://*/api/personal_access_token/list'
+const MINT_URL = 'http://*/api/personal_access_token'
+
+/**
+ * Registers an MSW handler that returns the given token list for the list query.
+ * @param tokens - Masked token rows to serve from GET /personal_access_token/list.
+ * @returns Nothing; the handler is added for the current test only.
+ * @example respondWithTokenList([])
+ */
+const respondWithTokenList = (tokens: Res.PersonalAccessToken[]): void => {
+  server.use(http.get(LIST_URL, () => HttpResponse.json({ tokens })))
+}
+
+beforeEach(() => {
+  // Fresh RTK Query cache per test so a prior test's list/mint result never bleeds in.
+  store.dispatch(API.util.resetApiState())
+})
+
+describe('ExtensionToken settings section', () => {
+  it('reveals the freshly minted raw token once after generating', async () => {
+    // Arrange
+    respondWithTokenList([])
+    server.use(
+      http.post(MINT_URL, () =>
+        HttpResponse.json(
+          {
+            id: 1,
+            name: 'Chrome extension',
+            tokenSuffix: 'aaaa',
+            createdAt: '2026-05-30T00:00:00.000Z',
+            token: RAW_TOKEN,
+          },
+          { status: 201 },
+        ),
+      ),
+    )
+    const user = userEvent.setup()
+    TestRenderer(<ExtensionToken />)
+
+    // Act
+    await user.type(screen.getByTestId('token-name-input'), 'Chrome extension')
+    await user.click(screen.getByTestId('generate-token-btn'))
+
+    // Assert
+    expect(await screen.findByTestId('revealed-token')).toHaveTextContent(
+      RAW_TOKEN,
+    )
+  })
+
+  it('copies the revealed token to the clipboard and confirms inline', async () => {
+    // Arrange
+    respondWithTokenList([])
+    server.use(
+      http.post(MINT_URL, () =>
+        HttpResponse.json(
+          {
+            id: 1,
+            name: 'Chrome extension',
+            tokenSuffix: 'aaaa',
+            createdAt: '2026-05-30T00:00:00.000Z',
+            token: RAW_TOKEN,
+          },
+          { status: 201 },
+        ),
+      ),
+    )
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    const user = userEvent.setup()
+    // jsdom exposes navigator.clipboard as a getter-only accessor, so redefine it with
+    // a concrete spy the component's handler can call.
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: { writeText },
+    })
+    TestRenderer(<ExtensionToken />)
+    await user.type(screen.getByTestId('token-name-input'), 'Chrome extension')
+    await user.click(screen.getByTestId('generate-token-btn'))
+    await screen.findByTestId('revealed-token')
+
+    // Act
+    await user.click(screen.getByTestId('copy-token-btn'))
+
+    // Assert
+    expect(writeText).toHaveBeenCalledWith(RAW_TOKEN)
+    expect(await screen.findByText('Copied!')).toBeInTheDocument()
+  })
+
+  it('lists existing tokens masked as nsx_pat_…suffix, never the raw value', async () => {
+    // Arrange
+    respondWithTokenList([
+      {
+        id: 1,
+        name: 'Chrome extension',
+        tokenSuffix: 'wxyz',
+        createdAt: '2026-05-30T00:00:00.000Z',
+        lastUsedAt: null,
+        revokedAt: null,
+      },
+    ])
+    TestRenderer(<ExtensionToken />)
+
+    // Act
+    const maskedLabel = await screen.findByText('nsx_pat_…wxyz')
+
+    // Assert — only the masked label is shown; no reveal panel, but a revoke control exists.
+    expect(maskedLabel).toBeInTheDocument()
+    expect(screen.getByTestId('revoke-token-btn-1')).toBeInTheDocument()
+    expect(screen.queryByTestId('revealed-token')).not.toBeInTheDocument()
+  })
+
+  it('keeps the form and its input when generation fails with a 5xx', async () => {
+    // Arrange
+    respondWithTokenList([])
+    server.use(
+      http.post(MINT_URL, () =>
+        HttpResponse.json({ error: 'Internal Server Error' }, { status: 500 }),
+      ),
+    )
+    const user = userEvent.setup()
+    TestRenderer(<ExtensionToken />)
+
+    // Act
+    await user.type(screen.getByTestId('token-name-input'), 'My token')
+    await user.click(screen.getByTestId('generate-token-btn'))
+
+    // Assert — an error is shown, no token is revealed, and the typed name is preserved.
+    expect(await screen.findByTestId('token-error')).toBeInTheDocument()
+    expect(screen.queryByTestId('revealed-token')).not.toBeInTheDocument()
+    expect(screen.getByTestId('token-name-input')).toHaveValue('My token')
+  })
+})

--- a/src/pages/Dashboard/Setting/ExtensionToken.tsx
+++ b/src/pages/Dashboard/Setting/ExtensionToken.tsx
@@ -1,0 +1,229 @@
+import React, { memo, useState } from 'react'
+
+import Button from '@/src/components/Button'
+import {
+  useGetPersonalAccessTokensQuery,
+  useMintPersonalAccessTokenMutation,
+  useRevokePersonalAccessTokenMutation,
+} from '@/src/redux/API'
+
+/**
+ * Masks a PAT for the list so a usable credential is never rendered.
+ * @param tokenSuffix - The stored last-4 characters of the raw token.
+ * @returns A masked label of the form `nsx_pat_…<suffix>`.
+ * @example maskToken('abcd') // => 'nsx_pat_…abcd'
+ */
+const maskToken = (tokenSuffix: string): string => `nsx_pat_…${tokenSuffix}`
+
+/**
+ * Formats an ISO timestamp (or null) for the token list.
+ * @param value - ISO date string, or null when the event never happened.
+ * @returns A locale date string, or '—' when the value is null.
+ * @example
+ * formatTimestamp('2026-05-30T00:00:00.000Z') // => '5/30/2026' (locale-dependent)
+ * formatTimestamp(null)                        // => '—'
+ */
+const formatTimestamp = (value: string | null): string =>
+  value ? new Date(value).toLocaleDateString() : '—'
+
+/**
+ * Settings section that mints, reveals (once), lists, and revokes extension PATs (E13).
+ *
+ * Rendered under Settings → Extension Token. The owner generates a token here, copies
+ * it once from the reveal panel, then pastes it into the browser extension. The list is
+ * always masked; a failed mint/revoke keeps the form usable instead of losing state.
+ */
+const ExtensionToken: React.FC = memo(() => {
+  const { data, isLoading } = useGetPersonalAccessTokensQuery()
+  const [
+    mintToken,
+    { data: mintedToken, isLoading: isMinting, reset: resetMint },
+  ] = useMintPersonalAccessTokenMutation()
+  const [revokeToken, { isLoading: isRevoking }] =
+    useRevokePersonalAccessTokenMutation()
+
+  const [name, setName] = useState('')
+  const [didCopy, setDidCopy] = useState(false)
+  const [actionError, setActionError] = useState<string | null>(null)
+
+  const tokens = data?.tokens ?? []
+
+  const handleGenerate = async (event: React.FormEvent) => {
+    event.preventDefault()
+    setActionError(null)
+    const trimmedName = name.trim()
+    if (!trimmedName) return
+
+    try {
+      await mintToken({ name: trimmedName }).unwrap()
+      // Keep the just-revealed token visible; only clear the input + stale copy flag.
+      setName('')
+      setDidCopy(false)
+    } catch {
+      // A failed mint leaves the form intact so the owner can retry (W3 guard).
+      setActionError('Failed to generate token. Please try again.')
+    }
+  }
+
+  const handleCopy = async () => {
+    if (!mintedToken) return
+    await navigator.clipboard.writeText(mintedToken.token)
+    setDidCopy(true)
+  }
+
+  const handleDismissReveal = () => {
+    setDidCopy(false)
+    resetMint()
+  }
+
+  const handleRevoke = async (id: number) => {
+    setActionError(null)
+    try {
+      await revokeToken({ id }).unwrap()
+    } catch {
+      setActionError('Failed to revoke token. Please try again.')
+    }
+  }
+
+  return (
+    <section
+      data-testid="extension-token-setting"
+      className="mx-auto w-full max-w-2xl"
+    >
+      <h1 className="text-color-primary text-center text-3xl">
+        Extension Token
+      </h1>
+      <p className="mt-2 text-center text-sm text-gray-500">
+        Generate a token, paste it into the browser extension, and it can save
+        pages to your account. The raw token is shown only once.
+      </p>
+
+      {mintedToken ? (
+        <div
+          data-testid="token-reveal"
+          className="mt-6 rounded-md border border-amber-300 bg-amber-50 p-4"
+        >
+          <p className="text-sm font-medium text-amber-800">
+            Copy this token now — it will not be shown again.
+          </p>
+          <code
+            data-testid="revealed-token"
+            className="mt-2 block overflow-x-auto rounded bg-white px-3 py-2 font-mono text-sm break-all text-gray-800"
+          >
+            {mintedToken.token}
+          </code>
+          <div className="mt-3 flex items-center gap-3">
+            <Button
+              type="button"
+              variant="secondary"
+              onClick={handleCopy}
+              data-testid="copy-token-btn"
+            >
+              {didCopy ? 'Copied!' : 'Copy'}
+            </Button>
+            <button
+              type="button"
+              onClick={handleDismissReveal}
+              className="text-sm text-gray-500 underline hover:text-gray-700"
+              data-testid="dismiss-reveal-btn"
+            >
+              Done
+            </button>
+          </div>
+        </div>
+      ) : (
+        <form
+          onSubmit={handleGenerate}
+          className="mt-6 flex flex-col gap-3 sm:flex-row sm:items-center"
+        >
+          <input
+            type="text"
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            placeholder="Token name (e.g. Chrome extension)"
+            data-testid="token-name-input"
+            className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
+          />
+          <Button
+            type="submit"
+            variant="secondary"
+            disabled={isMinting || name.trim().length === 0}
+            data-testid="generate-token-btn"
+          >
+            {isMinting ? 'Generating…' : 'Generate'}
+          </Button>
+        </form>
+      )}
+
+      {actionError ? (
+        <p
+          role="alert"
+          data-testid="token-error"
+          className="mt-3 text-sm text-red-600"
+        >
+          {actionError}
+        </p>
+      ) : null}
+
+      <div className="mt-8">
+        {isLoading ? (
+          <p data-testid="token-list-loading" className="text-sm text-gray-500">
+            Loading…
+          </p>
+        ) : tokens.length === 0 ? (
+          <p data-testid="token-list-empty" className="text-sm text-gray-500">
+            No tokens yet.
+          </p>
+        ) : (
+          <ul data-testid="token-list" className="divide-y divide-gray-200">
+            {tokens.map((token) => (
+              <li
+                key={token.id}
+                data-testid={`token-row-${token.id}`}
+                className="flex items-center justify-between py-3"
+              >
+                <div className="min-w-0">
+                  <p className="font-mono text-sm text-gray-800">
+                    {maskToken(token.tokenSuffix)}
+                  </p>
+                  <p className="text-sm font-medium text-gray-700">
+                    {token.name}
+                    <span
+                      className={
+                        token.revokedAt
+                          ? 'ml-2 text-xs text-gray-400'
+                          : 'ml-2 text-xs text-green-600'
+                      }
+                    >
+                      {token.revokedAt ? 'Revoked' : 'Active'}
+                    </span>
+                  </p>
+                  <p className="text-xs text-gray-400">
+                    Created {formatTimestamp(token.createdAt)} · Last used{' '}
+                    {formatTimestamp(token.lastUsedAt)}
+                  </p>
+                </div>
+                {token.revokedAt ? null : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      handleRevoke(token.id)
+                    }}
+                    disabled={isRevoking}
+                    className="ml-4 shrink-0 text-sm text-red-600 underline hover:text-red-700 disabled:cursor-not-allowed disabled:opacity-50"
+                    data-testid={`revoke-token-btn-${token.id}`}
+                  >
+                    Revoke
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  )
+})
+ExtensionToken.displayName = 'ExtensionToken'
+
+export default ExtensionToken

--- a/src/pages/Dashboard/Setting/ExtensionToken.tsx
+++ b/src/pages/Dashboard/Setting/ExtensionToken.tsx
@@ -67,8 +67,17 @@ const ExtensionToken: React.FC = memo(() => {
 
   const handleCopy = async () => {
     if (!mintedToken) return
-    await navigator.clipboard.writeText(mintedToken.token)
-    setDidCopy(true)
+    // clipboard.writeText rejects in insecure contexts / when permission is denied,
+    // and navigator.clipboard can be undefined; degrade to a manual-copy prompt since
+    // the raw token is shown only once and an unhandled rejection would lose feedback.
+    try {
+      await navigator.clipboard.writeText(mintedToken.token)
+      setDidCopy(true)
+    } catch {
+      setActionError(
+        'Could not copy automatically. Please copy the token manually.',
+      )
+    }
   }
 
   const handleDismissReveal = () => {
@@ -141,6 +150,7 @@ const ExtensionToken: React.FC = memo(() => {
             value={name}
             onChange={(event) => setName(event.target.value)}
             placeholder="Token name (e.g. Chrome extension)"
+            aria-label="Token name"
             data-testid="token-name-input"
             className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:ring-1 focus:ring-indigo-500 focus:outline-none"
           />

--- a/src/pages/Dashboard/Setting/index.tsx
+++ b/src/pages/Dashboard/Setting/index.tsx
@@ -1,6 +1,7 @@
 import {
   CreditCardIcon,
   BuildingOfficeIcon,
+  KeyIcon,
   UserIcon,
   UsersIcon,
 } from '@heroicons/react/24/solid'
@@ -11,6 +12,7 @@ import { Link, Routes, Route, Outlet, useLocation } from 'react-router'
 
 import Layout from '@/src/components/Layout'
 
+import ExtensionToken from './ExtensionToken'
 import MyAccount from './MyAccount'
 
 const TabRouterContainer: React.FC<ComponentProps<'section'>> = ({
@@ -24,6 +26,7 @@ const TabRouterContainer: React.FC<ComponentProps<'section'>> = ({
 
 const tabs = [
   { name: 'My Account', icon: UserIcon, path: 'my-account' },
+  { name: 'Extension Token', icon: KeyIcon, path: 'extension-token' },
   { name: 'Company', icon: BuildingOfficeIcon, path: 'company' },
   { name: 'Team Members', icon: UsersIcon, path: 'team-member' },
   { name: 'Billing', icon: CreditCardIcon, path: 'billing' },
@@ -66,6 +69,7 @@ const Setting: React.FC = memo(() => {
         <Route path="/" element={<TabRouterContainer />}>
           <Route index element={<MyAccount />} />
           <Route path="my-account" element={<MyAccount />} />
+          <Route path="extension-token" element={<ExtensionToken />} />
           <Route path="company" element={<h1>Company</h1>} />
           <Route path="team-member" element={<h1>Team Member</h1>} />
           <Route path="billing" element={<h1>Billing</h1>} />

--- a/src/redux/API.ts
+++ b/src/redux/API.ts
@@ -55,7 +55,7 @@ const baseQueryWithReauth: BaseQueryFn<
 
 export const API = createApi({
   reducerPath: 'RTK_Query',
-  tagTypes: ['Posts', 'Tweets'],
+  tagTypes: ['Posts', 'Tweets', 'PersonalAccessTokens'],
   keepUnusedDataFor: 30,
   baseQuery: baseQueryWithReauth,
   endpoints: (builder) => ({
@@ -257,6 +257,34 @@ export const API = createApi({
         }),
       },
     ),
+    getPersonalAccessTokens: builder.query<Res.PersonalAccessTokenList, void>({
+      providesTags: ['PersonalAccessTokens'],
+      query: () => ({
+        method: 'GET',
+        url: 'personal_access_token/list',
+      }),
+    }),
+    mintPersonalAccessToken: builder.mutation<
+      Res.MintPersonalAccessToken,
+      { name: string }
+    >({
+      invalidatesTags: ['PersonalAccessTokens'],
+      query: (body) => ({
+        method: 'POST',
+        url: 'personal_access_token',
+        body,
+      }),
+    }),
+    revokePersonalAccessToken: builder.mutation<
+      Res.RevokePersonalAccessToken,
+      { id: number }
+    >({
+      invalidatesTags: ['PersonalAccessTokens'],
+      query: ({ id }) => ({
+        method: 'DELETE',
+        url: `personal_access_token/${id}`,
+      }),
+    }),
   }),
 })
 
@@ -274,4 +302,7 @@ export const {
   useGetHoverColorPreferenceQuery,
   useUpdateHoverColorPreferenceMutation,
   useUpdateProfileMutation,
+  useGetPersonalAccessTokensQuery,
+  useMintPersonalAccessTokenMutation,
+  useRevokePersonalAccessTokenMutation,
 } = API


### PR DESCRIPTION
## Summary

Lets the browser extension save reading-list "stocks" without a cookie login, using a scoped, DB-backed **Personal Access Token (PAT)**. The owner mints a token from the web Settings UI (raw `nsx_pat_<64hex>` shown once, SHA-256 hash stored), pastes it into the extension, and the extension sends `Authorization: Bearer nsx_pat_...` on the two stock-write endpoints only. Cookie login for the web app is untouched.

**Server** (`96b9fa31`, `53434887`)
- New `PersonalAccessToken` Prisma model + migration (`tokenHash` UNIQUE, FK → authors `ON DELETE CASCADE`, `revokedAt` / `expiresAt` / `lastUsedAt`).
- `authenticateStockPatToken` validates a PAT in one atomic query (not revoked, not expired) and hydrates the full session user. The `authenticateStockRequest` middleware dispatches: `Authorization` header → PAT path, otherwise → unchanged cookie session. A bad PAT never reads or clears auth cookies (U5 confused-deputy guard).
- PAT routes: mint (cookie-gated, rate-limited in prod), list (masked — last 4 only, never the hash), revoke (owner-scoped, idempotent).
- `/api/push_stock` + `/api/stock/exists` now sit behind `authenticateStockRequest`; `/stocklist` and `DELETE /stock/:id` stay cookie-only.
- Logger redaction: removed `console.error(JSON.stringify(error))` that serialized the Bearer header; pino redacts `authorization` / `token` paths.

**Web** (`0bf3203c`)
- Settings → "Extension Token" section to mint / copy-once / list / revoke PATs (RTK Query). W1–W3 component tests.

**Extension** (`610feb38`)
- Popup reads the PAT from `chrome.storage.local` and attaches it as a Bearer header on both stock calls. Additive connect / connected / reconnect UI; the save checkbox + POST stay unconditional, so the existing token-less e2e flow is unchanged — reconnect only triggers on a **token-present** 401.
- `VITE_API_URL` → `VITE_API_ENDPOINT` (origin only — `buildPushStockApiUrl` appends the path). Un-ignored `.env.{development,production}` so CI/prod builds inject the endpoint instead of falling back to localhost. Verified: the prod build's popup chunk targets `nsx.malloc.tokyo` (localhost count 0).
- `host_permissions` narrowed from `<all_urls>` to the two NSX origins (E15).

## Test Coverage
- **Server**: `personalAccessToken.test.ts` (mint / list / revoke, incl. new `"5abc" → 400 before any DB lookup` regression), `authenticateStockRequest.contract.test.ts` (U1–U8 confused-deputy / scope / cookie-fallback + new `lastUsedAt write failure still authenticates` regression).
- **Web**: `ExtensionToken.test.tsx` (W1–W3).
- **Extension**: `App.test.tsx` (X1–X4: paste panel shown w/o token, persist + connect, Bearer attach on save, 401 → reconnect) — runs in the browser-extension CI (vitest unit).
- Root vitest: **98 passed (36 files)**. `typecheck` + `lint` clean.
- **E2E** (Playwright, root + browser-extension) runs in CI against a freshly-migrated MySQL — the only gate that exercises the unskipped NSX-80 build-config e2e and the unconditional-checkbox invariant.

## Pre-Landing Review (adversarial, fresh context)
- **No P0/P1.** Auth bypass, scope limitation, token leakage, revocation immediacy, and the confused-deputy guard were each checked and ruled out against quoted code.
- **P2 fixed** (`53434887`): `lastUsedAt` made genuinely best-effort — it previously 500'd a *valid* token's save on a transient DB write failure; revoke id now `^\d+$`-guarded — `Number.parseInt('5abc', 10)` had silently parsed to `5`.
- **P2 accepted**: no total-token cap (owner-only mint → self-DoS only, single-user app); raw token resident in client memory until "Done" (inherent to the one-time-reveal UX).

## Known gaps / verification
- No automated test covers the **authenticated happy path end-to-end** (mint → paste → save → `200` + DB row): server tests mock Prisma, extension tests mock axios, and the success-path e2e (NSX-81) stays skipped pending real-DB PAT provisioning. Token format / hash alignment checks out on paper. **The real verification is a post-deploy prod smoke test.**

## Test plan
- [x] Root vitest: 98 passed (36 files)
- [x] `typecheck` + `lint` clean (max-warnings=0)
- [x] Prod extension build injects `nsx.malloc.tokyo` (not localhost)
- [ ] CI: test / typecheck / lint / browser-extension E2E green
- [ ] Post-deploy prod smoke: mint → paste → save → `200` + `personal_access_tokens` row

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal Access Token (PAT) management: generate, view masked tokens, copy revealed token once, and revoke from dashboard and extension popup.

* **Enhancements**
  * Extension popup now supports PAT-based auth with connect/disconnect and reconnect prompts; improved save feedback and error handling.
  * Reduced extension permissions to specific API origins.

* **Tests**
  * Added unit, integration, and e2e tests covering PAT flows and auth behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/laststance/nsx/pull/3786?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->