### PR TITLE
fix(deploy): anchor rsync excludes to transfer root to prevent exit 23

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,7 +228,9 @@ jobs:
                 return 1
               fi
 
-              rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$rollback_dir"/ "$remote_dir"/
+              # Anchored excludes ('/'-prefixed) protect only the top-level .env/logs/run, so
+              # --delete can still prune stale nested node_modules (see artifact-sync rsync, exit 23).
+              rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' "$rollback_dir"/ "$remote_dir"/
               cd "$remote_dir"
               if sudo pm2 describe server >/dev/null 2>&1; then
                 sudo pm2 reload ecosystem.config.js --update-env
@@ -243,7 +245,9 @@ jobs:
 
             capture_rollback_artifacts() {
               set +e
-              rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$remote_dir"/ "$rollback_dir"/
+              # Anchored excludes ('/'-prefixed) protect only the top-level .env/logs/run, so
+              # --delete can still prune stale nested node_modules (see artifact-sync rsync, exit 23).
+              rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' "$remote_dir"/ "$rollback_dir"/
               rollback_status=$?
               set -e
 
@@ -337,7 +341,10 @@ jobs:
             reset_staging_dir || fail_deployment "Failed to clear migration staging directory"
             tar -xzf "$remote_archive" -C "$staging_dir" || fail_deployment "Failed to re-extract clean deployment artifact"
 
-            rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' "$staging_dir"/ "$remote_dir"/ || fail_deployment "Failed to sync deployment artifact"
+            # Anchor excludes with a leading '/' so they shield ONLY top-level runtime state
+            # (.env, logs/, run/). Unanchored patterns also matched deep node_modules dirs
+            # named logs/, protecting stale nested @sentry trees from --delete → rsync exit 23.
+            rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' "$staging_dir"/ "$remote_dir"/ || fail_deployment "Failed to sync deployment artifact"
             deployment_applied="true"
 
             cd "$remote_dir"


### PR DESCRIPTION
## Problem

Every push-to-`main` deploy was aborting at the artifact-sync `rsync` step with **exit 23** (`cannot delete non-empty directory: node_modules/@sentry/.../node_modules/@sentry/core/build/...`), **before** the `pm2 restart`. Net effect of a "failed" deploy: the new bundle (`server_build/server/index.js`) *was* synced to disk and `prisma migrate deploy` *was* applied, but PM2 kept running the **old code**. Surfaced on the PR #3786 deploy after a Dependabot `@sentry` bump.

## Root cause

All three deploy rsyncs used **unanchored** excludes:

```
rsync -a --delete --exclude='.env' --exclude='logs/' --exclude='run/' ...
```

An unanchored pattern like `logs/` matches a directory of that name **at any depth**, and rsync protects excluded paths on the receiver from `--delete`. The hoisted node_modules tree contains deep dirs literally named `logs/`:

```
node_modules/@sentry/node/node_modules/@sentry/core/build/esm/logs
node_modules/@sentry/node/node_modules/@sentry/core/build/cjs/logs
node_modules/@sentry/opentelemetry/node_modules/@sentry/core/build/esm/logs
...
```

When a version bump hoists `@sentry/core` to the top level, the stale **nested** `@sentry/*/node_modules/@sentry/core/` trees should be deleted — but their `build/*/logs/` subdirs were protected by `--exclude='logs/'`, leaving the parents non-empty. rsync cannot remove a non-empty directory → exit 23 → `fail_deployment` → restart skipped.

## Fix

Anchor every exclude to the transfer root with a leading `/`, on all three rsyncs (artifact sync + both rollback rsyncs):

```
rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' ...
```

`/logs/` now protects **only** `"$remote_dir"/logs/` (the intended top-level runtime dir), not deep `node_modules/.../logs/`, so `--delete` can prune stale nested node_modules and the sync completes through to `pm2 restart`. Top-level `/.env`, `/logs/`, `/run/` stay protected exactly as before (preserves the production `.env`, PM2 logs, and the live mysqld socket dir — the CLAUDE.md "must not rm -rf the top-level run/ tree" gotcha still holds).

## Verification (empirical, on the production host — rsync 3.2.7)

Reproduced the exact failing structure in `/tmp` (touches no real paths):

| exclude | nested `@sentry` tree | top-level `logs/` |
|---|---|---|
| `--exclude='logs/'` (old) | **survives** — `cannot delete non-empty directory: @sentry/core/build/esm` | protected |
| `--exclude='/logs/'` (new) | **removed** — `No such file or directory` | preserved (`app.log` kept) |

This proves both that the unanchored exclude is the cause and that anchoring preserves the intended top-level protection. (CI does not exercise the deploy SSH path, so this host-level repro is the real test, not green CI.)

## Notes

- **Self-healing.** The first deploy carrying this fix deletes the stale nested `@sentry/core` dirs (dated before the bump) automatically — no manual production cleanup needed.
- **`scripts/deploy` (manual path) is unaffected** — its rsyncs use neither `--delete` nor these excludes and never sync `node_modules`. The only other rsync in the repo (`scripts/backup`) already uses an anchored `--exclude='/tmp/'`.
- **No `--force` / `--delete-after`.** With the protect rule corrected there are no un-deletable dirs left; adding those flags would only mask a future protect-rule regression instead of surfacing it as a loud exit 23.

## Risk

Low — CI-workflow change only. Production is untouched until the next deploy, which this change makes complete through `pm2 restart`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced deployment safety by refining file protection patterns during rollback and synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->