### PR TITLE
fix: skip root-owned jiti cache in deploy rsync (exit 23)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -228,9 +228,9 @@ jobs:
                 return 1
               fi
 
-              # Anchored excludes ('/'-prefixed) protect only the top-level .env/logs/run, so
-              # --delete can still prune stale nested node_modules (see artifact-sync rsync, exit 23).
-              rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' "$rollback_dir"/ "$remote_dir"/
+              # Anchored excludes ('/'-prefixed) protect top-level .env/logs/run plus the root-owned
+              # node_modules/.cache the non-root rsync can't delete (see artifact-sync rsync, exit 23).
+              rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' --exclude='/node_modules/.cache/' "$rollback_dir"/ "$remote_dir"/
               cd "$remote_dir"
               if sudo pm2 describe server >/dev/null 2>&1; then
                 sudo pm2 reload ecosystem.config.js --update-env
@@ -245,9 +245,9 @@ jobs:
 
             capture_rollback_artifacts() {
               set +e
-              # Anchored excludes ('/'-prefixed) protect only the top-level .env/logs/run, so
-              # --delete can still prune stale nested node_modules (see artifact-sync rsync, exit 23).
-              rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' "$remote_dir"/ "$rollback_dir"/
+              # Anchored excludes ('/'-prefixed) protect top-level .env/logs/run plus the root-owned
+              # node_modules/.cache the non-root rsync can't delete (see artifact-sync rsync, exit 23).
+              rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' --exclude='/node_modules/.cache/' "$remote_dir"/ "$rollback_dir"/
               rollback_status=$?
               set -e
 
@@ -344,7 +344,9 @@ jobs:
             # Anchor excludes with a leading '/' so they shield ONLY top-level runtime state
             # (.env, logs/, run/). Unanchored patterns also matched deep node_modules dirs
             # named logs/, protecting stale nested @sentry trees from --delete → rsync exit 23.
-            rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' "$staging_dir"/ "$remote_dir"/ || fail_deployment "Failed to sync deployment artifact"
+            # /node_modules/.cache/ holds jiti's compiled prisma.config cache. A manual root deploy
+            # writes it root-owned, so this non-root Actions rsync can't --delete it → exit 23; skip it.
+            rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' --exclude='/node_modules/.cache/' "$staging_dir"/ "$remote_dir"/ || fail_deployment "Failed to sync deployment artifact"
             deployment_applied="true"
 
             cd "$remote_dir"


### PR DESCRIPTION
## Problem

The push-to-`main` deploy aborts at the artifact-sync `rsync` with **exit 23**, **before** `pm2 restart` — so the new bundle is synced to disk and `prisma migrate deploy` runs, but PM2 keeps serving the **old code** (same "silent failure" shape as #3787, different cause).

Runtime error from the failed run (`Extract and restart server` step):

```
rsync: [generator] delete_file: unlink(node_modules/.cache/jiti/nsx-prisma.config.88e0c7e4.mjs) failed: Permission denied (13)
cannot delete non-empty directory: node_modules/.cache/jiti
rsync error: some files/attrs were not transferred (see previous errors) (code 23) at main.c(1347) [sender=3.2.7]
```

## Root cause

`node_modules/.cache/jiti/` is jiti's compiled cache of `prisma.config.ts` (Prisma 7 loads its `.ts` config through jiti, which writes content-hashed output there). On the production host it is **owned by `root`**:

```
drwxr-xr-x 3 root root  node_modules/.cache
drwxr-xr-x 2 root root  node_modules/.cache/jiti
-rw-r--r-- 1 root root  node_modules/.cache/jiti/nsx-prisma.config.88e0c7e4.mjs
```

A manual `pnpm deploy` (`scripts/deploy`, which SSHes in as **root** per the maintainer's ssh config) runs `prisma migrate` and creates the cache root-owned. The **GitHub Actions** deploy rsync runs as a **non-root** user — it cannot `unlink` a root-owned file inside a root-owned `0755` directory → `--delete` fails → exit 23.

## Fix

Add an anchored `--exclude='/node_modules/.cache/'` to all three deploy rsyncs (artifact sync + both rollback rsyncs):

```
rsync -a --delete --exclude='/.env' --exclude='/logs/' --exclude='/run/' --exclude='/node_modules/.cache/' ...
```

`--delete` now never touches the jiti cache — a **regenerable runtime artifact** that has no business being pruned by a deploy — so ownership is irrelevant. Anchored with a leading `/` so it matches **only** the top-level `node_modules/.cache`, not deep `node_modules/**/.cache` dirs (same anchoring discipline as the `/logs/` fix in #3787).

## Verification (production host, rsync 3.2.7)

- `find /home/deploy/nsx/node_modules -uid 0` returns **only** `.cache` and its contents — **zero** other root-owned paths. So this single exclude fully unblocks the deploy; there is no second root-owned path waiting to fail the next run.
- This run also **empirically confirmed the #3787 anchor fix**: there were **no `@sentry` "cannot delete" errors** this time — the deploy got all the way past the nested-node_modules pruning and stopped only at the `.cache` wall.

## Production state (no regression)

The failed deploy aborted at the rsync, **before** `pm2 restart` and **before** `deployment_applied=true`, so it neither restarted PM2 nor rolled back. Production is healthy: `post_list` → HTTP 200, PM2 `server` online with ~16h uptime (= untouched by the failed deploy). This PR makes the **next** deploy complete through `pm2 restart`.

## Notes

- **Code-only. Production is untouched** by this change.
- **Latent follow-up (not required here):** the root-owned `.cache/jiti` stays on disk. While `prisma.config.ts` is unchanged (hash `88e0c7e4`), jiti only *reads* the world-readable cache — fine. If `prisma.config.ts` ever changes, jiti must *write* a new hash file into the root-owned dir as the non-root deploy user, which may fail. A one-time `rm -rf node_modules/.cache` on the host (as root) would clear that, but it is a production mutation and out of scope for this CI-only fix.
- **`scripts/deploy` (manual path) is unaffected** — its rsyncs use neither `--delete` nor these excludes and never sync `node_modules`.

## Risk

Low — CI-workflow change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved deployment reliability by resolving cache directory handling issues during rollback and synchronization operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->