### PR TITLE
fix(lint): drop unnecessary null as never casts

### DIFF
--- a/server/lib/authenticateStockRequest.contract.test.ts
+++ b/server/lib/authenticateStockRequest.contract.test.ts
@@ -195,7 +195,7 @@ describe('authenticateStockRequest', () => {
 
   it('responds 401 without clearing auth cookies when the Bearer PAT is invalid or revoked', async () => {
     // Arrange — a Bearer PAT that matches no active row, alongside live auth cookies.
-    findPatMock.mockResolvedValue(null as never)
+    findPatMock.mockResolvedValue(null)
     const req = buildRequest(`Bearer ${VALID_RAW_TOKEN}`, {
       accessToken: 'owner-access-cookie',
       refreshToken: 'owner-refresh-cookie',

--- a/server/routes/personalAccessToken.test.ts
+++ b/server/routes/personalAccessToken.test.ts
@@ -164,7 +164,7 @@ describe('revokePersonalAccessTokenHandler', () => {
 
   it('responds 404 for a token that is unknown or owned by someone else', async () => {
     // Arrange
-    findFirstMock.mockResolvedValue(null as never)
+    findFirstMock.mockResolvedValue(null)
     const req = {
       authenticatedUser: { id: OWNER_ID },
       params: { id: '999' },


### PR DESCRIPTION
## Summary
- Lint CI on `main` failed after #3840: `@typescript-eslint/no-unnecessary-type-assertion` now flags `mockResolvedValue(null as never)`.
- Drop the two `as never` casts in PAT auth tests. `null` is already accepted.

## Test plan
- [x] `pnpm lint` (matches CI)
- [x] Vitest on the two affected files (15 tests)
- [ ] GitHub Lint workflow on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated authentication and personal access token test mocks for clearer handling of invalid, revoked, unknown, and foreign tokens.
  * Test behavior and assertions remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->